### PR TITLE
Fix PassingPoincare.compute_frequencies

### DIFF
--- a/src/simsopt/field/trajectory_helpers.py
+++ b/src/simsopt/field/trajectory_helpers.py
@@ -358,7 +358,7 @@ class PassingPoincare:
                 continue
             delta_theta = np.array(theta_traj[1::]) - np.array(theta_traj[0:-1])
 
-            delta_t = np.array(t_traj[1::]) - np.array(t_traj[0:-1])
+            delta_t = t_traj[1::]
             delta_zeta = 2 * np.pi * self.sign_vpar * sign_G
 
             # Average over wells along one field line


### PR DESCRIPTION
Corrected delta_t expression.

PassingPoincare.passing_map returns time taken from the previous zeta=0 crossing, so the time between crossings in compute_frequencies should be `delta_t = t_traj[1::]`

Previous expression caused the computed frequencies to be ~Nmaps times larger than expected.

(Consider similar correction in TrappedPoincare.compute_frequencies)