### PR TITLE
The Jacobian sign can be negative. In this instance, the probability …

### DIFF
--- a/src/firm3d/field/tracing_helpers.py
+++ b/src/firm3d/field/tracing_helpers.py
@@ -50,7 +50,17 @@ def initialize_position_uniform_surf(
     modB = field.modB()
     J = (G + iota * I) / (modB**2)
 
-    J_max = np.max(J)
+    J_vals = J.flatten()
+    if np.all(J_vals > 0):
+        sign = 1
+    elif np.all(J_vals < 0):
+        sign = -1
+    else:
+        raise ValueError(
+            "Jacobian J = (G + iota*I)/B^2 changes sign across the surface. "
+            "Cannot form a valid probability distribution for rejection sampling."
+        )
+    J_max = np.max(J_vals * sign)
 
     theta_init = []
     zeta_init = []
@@ -72,7 +82,7 @@ def initialize_position_uniform_surf(
             )
 
             # Normalize the Jacobian
-            prob_norm = J / J_max
+            prob_norm = J * sign / J_max
 
             if rand1 <= prob_norm:
                 s_init.append(s)
@@ -165,10 +175,24 @@ def initialize_position_profile(
     modB = field.modB()
     J = (G + iota * I) / (modB**2)
 
+    # The Jacobian must be single-signed over the domain for rejection sampling
+    # to work correctly.  Some equilibria have J < 0 everywhere; flip the sign
+    # so the probability weight is always positive.
+    J_vals = J[:, 0]
+    if np.all(J_vals > 0):
+        sign = 1
+    elif np.all(J_vals < 0):
+        sign = -1
+    else:
+        raise ValueError(
+            "Jacobian J = (G + iota*I)/B^2 changes sign across the domain. "
+            "Cannot form a valid probability distribution for rejection sampling."
+        )
+
     # Compute normalized profile values on the grid
     profile_values = np.array([profile(s) for s in s_grid.flatten()])
     prob_max = np.max(
-        J[:, 0] * profile_values
+        J_vals * sign * profile_values
     )  # Normalize by the maximum value of J * profile
 
     theta_init = []
@@ -192,7 +216,7 @@ def initialize_position_profile(
             )
 
             # Normalize the probability
-            prob_norm = J * profile(s) / prob_max
+            prob_norm = J * sign * profile(s) / prob_max
 
             if rand1 <= prob_norm:
                 s_init.append(s)


### PR DESCRIPTION
The probability distribution of Alphas can be computed incorrectly if the Jacobian is negative. This causes J_max to actually be the smallest value, leading to a soft failure and uniform particle distribution. This commit proposes a simple fix.

## Summary by Sourcery

Ensure Jacobian-based probability distributions are valid for rejection sampling by enforcing a single sign and handling negative Jacobians.

Bug Fixes:
- Correct handling of cases where the Jacobian is negative so that probability weights remain positive and rejection sampling behaves correctly.
- Detect and reject configurations where the Jacobian changes sign across the surface or domain, avoiding invalid probability distributions.