### PR TITLE
Register pybind classes as py::local_module() to avoid issues with simsopt

### DIFF
--- a/src/firm3dpp/python_boozermagneticfield.cpp
+++ b/src/firm3dpp/python_boozermagneticfield.cpp
@@ -22,7 +22,7 @@ void init_boozermagneticfields(py::module_ &m){
       BoozerMagneticField,
       BoozerMagneticFieldTrampoline<BoozerMagneticField>,
       shared_ptr<BoozerMagneticField>
-      >(m, "BoozerMagneticField", "")
+      >(m, "BoozerMagneticField", py::module_local(), "")
     .def(py::init<double,string>());
     mf
     .def(
@@ -406,7 +406,7 @@ void init_boozermagneticfields(py::module_ &m){
       InterpolatedBoozerField,
       BoozerMagneticField,
       shared_ptr<InterpolatedBoozerField>
-      >(m, "InterpolatedBoozerField")
+      >(m, "InterpolatedBoozerField", py::module_local())
       .def(
           py::init<shared_ptr<BoozerMagneticField>,
           InterpolationRule,
@@ -537,7 +537,7 @@ void init_boozermagneticfields(py::module_ &m){
         ShearAlfvenWave,
         ShearAlfvenWaveTrampoline<ShearAlfvenWave>,
         shared_ptr<ShearAlfvenWave>
-        >(m, "ShearAlfvenWave", "")
+        >(m, "ShearAlfvenWave", py::module_local(), "")
         .def(py::init<shared_ptr<BoozerMagneticField>>())
         .def(
             "Phi",
@@ -610,7 +610,7 @@ void init_boozermagneticfields(py::module_ &m){
         );
 
     // Phihat:
-    py::class_<Phihat>(m, "Phihat")
+    py::class_<Phihat>(m, "Phihat", py::module_local())
         .def(
             py::init<const std::vector<double>&,
             const std::vector<double>&>()
@@ -624,7 +624,7 @@ void init_boozermagneticfields(py::module_ &m){
         ShearAlfvenHarmonic,
         ShearAlfvenWave,
         shared_ptr<ShearAlfvenHarmonic>
-        >(m, "ShearAlfvenHarmonic")
+        >(m, "ShearAlfvenHarmonic", py::module_local())
         .def(py::init<const Phihat&, int, int, double, double, shared_ptr<BoozerMagneticField>>())
         .def_readwrite("Phim", &ShearAlfvenHarmonic::Phim)
         .def_readwrite("Phin", &ShearAlfvenHarmonic::Phin)
@@ -642,7 +642,7 @@ void init_boozermagneticfields(py::module_ &m){
         ShearAlfvenWavesSuperposition,
         ShearAlfvenWave,
         shared_ptr<ShearAlfvenWavesSuperposition>
-        >(m, "ShearAlfvenWavesSuperposition")
+        >(m, "ShearAlfvenWavesSuperposition", py::module_local())
         .def(py::init<shared_ptr<ShearAlfvenWave>>())
         .def("add_wave", &ShearAlfvenWavesSuperposition::add_wave)
         .def("set_points", &ShearAlfvenWavesSuperposition::set_points)

--- a/src/firm3dpp/python_interpolant.cpp
+++ b/src/firm3dpp/python_interpolant.cpp
@@ -25,20 +25,20 @@ void interpolate_batch_mpi(RegularGridInterpolant3D<Array2>& self,
 
 void init_interpolant(py::module_ &m){
 
-    py::class_<InterpolationRule, shared_ptr<InterpolationRule>>(m, "InterpolationRule", "Abstract class for interpolation rules on an interval.")
+    py::class_<InterpolationRule, shared_ptr<InterpolationRule>>(m, "InterpolationRule", py::module_local(), "Abstract class for interpolation rules on an interval.")
         .def_readonly("degree", &InterpolationRule::degree, "The degree of the polynomial. The number of interpolation points is `degree+1`.")
         // nodes and scalings exposed for InterpolatedBoozerField serialization
         .def_readonly("nodes", &InterpolationRule::nodes, "The interpolation nodes within each cell.")
         .def_readonly("scalings", &InterpolationRule::scalings, "The scaling factors for interpolation weights.");
 
-    py::class_<UniformInterpolationRule, shared_ptr<UniformInterpolationRule>, InterpolationRule>(m, "UniformInterpolationRule", "Polynomial interpolation using equispaced points.")
+    py::class_<UniformInterpolationRule, shared_ptr<UniformInterpolationRule>, InterpolationRule>(m, "UniformInterpolationRule", py::module_local(), "Polynomial interpolation using equispaced points.")
         .def(py::init<int>())
         .def_readonly("degree", &UniformInterpolationRule::degree, "The degree of the polynomial. The number of interpolation points is `degree+1`.");
-    py::class_<ChebyshevInterpolationRule, shared_ptr<ChebyshevInterpolationRule>, InterpolationRule>(m, "ChebyshevInterpolationRule", "Polynomial interpolation using Chebyshev points.")
+    py::class_<ChebyshevInterpolationRule, shared_ptr<ChebyshevInterpolationRule>, InterpolationRule>(m, "ChebyshevInterpolationRule", py::module_local(), "Polynomial interpolation using Chebyshev points.")
         .def(py::init<int>())
         .def_readonly("degree", &ChebyshevInterpolationRule::degree, "The degree of the polynomial. The number of interpolation points is `degree+1`.");
 
-    py::class_<RegularGridInterpolant3D<Array2>, shared_ptr<RegularGridInterpolant3D<Array2>>>(m, "RegularGridInterpolant3D",
+    py::class_<RegularGridInterpolant3D<Array2>, shared_ptr<RegularGridInterpolant3D<Array2>>>(m, "RegularGridInterpolant3D", py::module_local(),
             R"pbdoc(
             Interpolates a (vector valued) function on a uniform grid.
             This interpolant is optimized for fast function evaluation (at the cost of memory usage). The main purpose of this class is to be used to interpolate magnetic fields and then use the interpolant for tasks such as fieldline or particle tracing for which the field needs to be evaluated many many times.

--- a/src/firm3dpp/python_tracing.cpp
+++ b/src/firm3dpp/python_tracing.cpp
@@ -58,16 +58,16 @@ extern "C" vector<double> test_timestep_saw_nok(py::array_t<double> quad_pts, py
 #endif
 
 void init_tracing(py::module_ &m){
-    py::class_<StoppingCriterion, shared_ptr<StoppingCriterion>>(m, "StoppingCriterion");
-    py::class_<IterationStoppingCriterion, shared_ptr<IterationStoppingCriterion>, StoppingCriterion>(m, "IterationStoppingCriterion")
+    py::class_<StoppingCriterion, shared_ptr<StoppingCriterion>>(m, "StoppingCriterion", py::module_local());
+    py::class_<IterationStoppingCriterion, shared_ptr<IterationStoppingCriterion>, StoppingCriterion>(m, "IterationStoppingCriterion", py::module_local())
         .def(py::init<int>());
-    py::class_<MaxToroidalFluxStoppingCriterion, shared_ptr<MaxToroidalFluxStoppingCriterion>, StoppingCriterion>(m, "MaxToroidalFluxStoppingCriterion")
+    py::class_<MaxToroidalFluxStoppingCriterion, shared_ptr<MaxToroidalFluxStoppingCriterion>, StoppingCriterion>(m, "MaxToroidalFluxStoppingCriterion", py::module_local())
         .def(py::init<double>());
-    py::class_<MinToroidalFluxStoppingCriterion, shared_ptr<MinToroidalFluxStoppingCriterion>, StoppingCriterion>(m, "MinToroidalFluxStoppingCriterion")
+    py::class_<MinToroidalFluxStoppingCriterion, shared_ptr<MinToroidalFluxStoppingCriterion>, StoppingCriterion>(m, "MinToroidalFluxStoppingCriterion", py::module_local())
         .def(py::init<double>());
-    py::class_<ToroidalTransitStoppingCriterion, shared_ptr<ToroidalTransitStoppingCriterion>, StoppingCriterion>(m, "ToroidalTransitStoppingCriterion")
+    py::class_<ToroidalTransitStoppingCriterion, shared_ptr<ToroidalTransitStoppingCriterion>, StoppingCriterion>(m, "ToroidalTransitStoppingCriterion", py::module_local())
         .def(py::init<int>());
-    py::class_<StepSizeStoppingCriterion, shared_ptr<StepSizeStoppingCriterion>, StoppingCriterion>(m, "StepSizeStoppingCriterion")
+    py::class_<StepSizeStoppingCriterion, shared_ptr<StepSizeStoppingCriterion>, StoppingCriterion>(m, "StepSizeStoppingCriterion", py::module_local())
         .def(py::init<double>());
 
     m.def("particle_guiding_center_boozer_tracing", &particle_guiding_center_boozer_tracing,


### PR DESCRIPTION
This addresses the error https://github.com/ColumbiaStellaratorTheory/firm3d/issues/53

where concurrent import of simsoptpp and firm3dpp throws

```bash
 import firm3dpp
ImportError: generic_type: type "RegularGridInterpolant3D" is already registered!
```

or

```
ImportError: generic_type: type "StoppingCriterion" is already registered!
```

from name conflict betwin similarly named registrations of simsopt and firm3d classes in Pybind.

## Summary by Sourcery

Bug Fixes:
- Prevent ImportError from duplicate pybind11 type registrations when importing firm3dpp alongside other modules defining similarly named classes such as simsoptpp.