### PR TITLE
Fix set_points to accept non-C-contiguous arrays and validate shape

### DIFF
--- a/src/firm3d/field/boozermagneticfield.py
+++ b/src/firm3d/field/boozermagneticfield.py
@@ -401,6 +401,33 @@ class BoozerMagneticField(sopp.BoozerMagneticField):
         self.field_type = field_type
         sopp.BoozerMagneticField.__init__(self, psi0, field_type)
 
+    def set_points(self, points):
+        """
+        Set the points where the field should be evaluated in Boozer
+        coordinates `(s,theta,zeta)`.
+
+        Args:
+            points: A (n, 3) array-like of `(s,theta,zeta)` points. The
+                underlying C++ binding requires a C-contiguous
+                row-major array, so arrays that are views with a
+                different memory layout (e.g. the result of
+                ``np.vstack(...).T``) are copied into a contiguous
+                array here; this avoids a confusing pybind11
+                "incompatible function arguments" error for otherwise
+                valid input. The binding also does not itself validate
+                the number of columns, so a wrong shape like (3, n) is
+                checked explicitly here rather than being silently
+                misread as n points.
+        """
+        points = np.ascontiguousarray(points, dtype=np.float64)
+        if points.ndim != 2 or points.shape[1] != 3:
+            raise ValueError(
+                "points must have shape (n, 3), corresponding to "
+                f"(s, theta, zeta) for each of n points; got shape "
+                f"{points.shape}."
+            )
+        return sopp.BoozerMagneticField.set_points(self, points)
+
     def _modB_derivs_impl(self, modB_derivs):
         self._dmodBds_impl(modB_derivs[:, 0:1])
         self._dmodBdtheta_impl(modB_derivs[:, 1:2])

--- a/src/firm3d/field/boozermagneticfield.py
+++ b/src/firm3d/field/boozermagneticfield.py
@@ -407,17 +407,7 @@ class BoozerMagneticField(sopp.BoozerMagneticField):
         coordinates `(s,theta,zeta)`.
 
         Args:
-            points: A (n, 3) array-like of `(s,theta,zeta)` points. The
-                underlying C++ binding requires a C-contiguous
-                row-major array, so arrays that are views with a
-                different memory layout (e.g. the result of
-                ``np.vstack(...).T``) are copied into a contiguous
-                array here; this avoids a confusing pybind11
-                "incompatible function arguments" error for otherwise
-                valid input. The binding also does not itself validate
-                the number of columns, so a wrong shape like (3, n) is
-                checked explicitly here rather than being silently
-                misread as n points.
+            points: A (n, 3) array-like of `(s,theta,zeta)` points.
         """
         points = np.ascontiguousarray(points, dtype=np.float64)
         if points.ndim != 2 or points.shape[1] != 3:


### PR DESCRIPTION
BoozerMagneticField.set_points (inherited by InterpolatedBoozerField) is bound to a C++ function expecting a C-contiguous row-major array. Arrays built via patterns like np.vstack((s, theta, zeta)).T are Fortran-contiguous despite matching shape/dtype, which pybind11 rejects with a confusing "incompatible function arguments" TypeError even though the input is otherwise valid.

The binding also never validated the number of columns, so a wrong-shaped (3, n) array was silently misread as n points instead of raising an error.

Fixes #58.

## Summary by Sourcery

Validate and normalize BoozerMagneticField point inputs before passing them to the C++ binding.

New Features:
- Add a Python-level set_points method on BoozerMagneticField that accepts generic array-like inputs for Boozer coordinates.

Bug Fixes:
- Ensure non-C-contiguous but otherwise valid (n, 3) arrays are copied to a contiguous layout to avoid pybind11 argument errors.
- Validate that point arrays have exactly three columns and raise a clear ValueError for wrong shapes instead of silently misinterpreting them.

Enhancements:
- Improve user-facing error messaging around invalid point array shapes and layouts when setting Boozer field evaluation points.