### PR TITLE
Fix documentation/docstring accuracy issues across README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ B(s,\theta,\zeta) = B_0 \left(1 + \overline{\eta} \sqrt{2s\psi_0/\overline{B}}\c
 the covariant components of equilibrium field are,
 
 ```math
-G(s) = G_0 + \sqrt{2s\psi_0/\overline{B}} G_1 \\
+G(s) = G_0 + s G_1 \\
 
-I(s) = I_0 + \sqrt{2s\psi_0/\overline{B}} I_1 \\
+I(s) = I_0 + s I_1 \\
 
 K(s,\theta,\zeta) = \sqrt{2s\psi_0/\overline{B}} K_1 \sin(\theta - N \zeta),
 ```
@@ -101,7 +101,7 @@ This field takes an existing ``BoozerMagneticField`` instance, such as [BoozerRa
 Given an equilibrium field $\textbf{B}_0$, a shear Alfvén wave is modeled through the perturbed electrostatic potential, $\Phi$, and parameter $\alpha$ defining the perturbed vector potential $\delta \textbf{A} = \alpha \textbf{B}_0$. The perturbed electric and magnetic fields then satisfy:
 
 ```math
-\delta \textbf{E} = -\nabla \Phi - \frac{\partial \alpha}{\partial t} \\
+\delta \textbf{E} = -\nabla \Phi - B_0 \frac{\partial \alpha}{\partial t} \\
 \delta \textbf{B} = \nabla \times \left(\alpha \textbf{B}_0 \right).
 ```
 
@@ -136,19 +136,19 @@ See Paul et al., JPP (2023; 89(5):905890515. doi:10.1017/S0022377823001095) for 
 
 Guiding center integration in Boozer coordinates is performed using equations of motion obtained from the Littlejohn Lagrangian,
 ```math
-L(\psi,\theta,\zeta,\rho_{||})  = q\left(\left[\psi + I  \rho_{||}\right] \dot{\theta} + \left[- \chi + G \rho_{||} \right] \dot{\zeta} + \rho_{||} K \dot{\psi}\right)  - \frac{\rho_{||}^2 B_0^2q^2}{2m} - \mu B_0 ,
+L(\psi,\theta,\zeta,\rho_{||})  = q\left(\left[\psi + I  \rho_{||}\right] \dot{\theta} + \left[- \chi + G \rho_{||} \right] \dot{\zeta} + \rho_{||} K \dot{\psi}\right)  - \frac{\rho_{||}^2 B^2q^2}{2m} - m\mu B ,
 ```
-where $2\pi \psi$ is the toroidal flux, $2\pi \chi$ is the poloidal flux, $q$ is the charge, $m$ is the mass$, $\rho_{||} = q v_{||}/(m B)$ and the covariant form of the magnetic field is,
+where $2\pi \psi$ is the toroidal flux, $2\pi \chi$ is the poloidal flux, $q$ is the charge, $m$ is the mass, $\rho_{||} = m v_{||}/(q B)$, $\mu = v_\perp^2/(2B)$ is the magnetic moment per unit mass (so that $m\mu B = \tfrac{1}{2}mv_\perp^2$, matching the convention used elsewhere in this document), and the covariant form of the magnetic field is,
 ```math
 \textbf{B} = G(\psi) \nabla \zeta + I(\psi) \nabla \theta + K(\psi,\theta,\zeta) \nabla \psi.
 ```
 See R. White, Theory of Tokamak Plasmas, Sec. 3.2.
 
-The trajectory information is saved as $(s,\theta,\zeta,v_{||})$, where $s = \psi_0$ is the toroidal flux normalized to its value on the boundary, $2\pi\psi_0$
+The trajectory information is saved as $(s,\theta,\zeta,v_{||})$, where $s = \psi/\psi_0$ is the toroidal flux normalized to its (signed) value on the boundary, $2\pi\psi_0$.
 
 Various integrators, equations of motion, and solver options are detailed below.
 
-### Perturbed guiding center integration
+### Vacuum and general modes
 
 The primary routine for unperturbed guiding center integration is ``trace_particles_boozer``.
 
@@ -179,7 +179,7 @@ In the case of ``mode='gc'`` we solve the general guiding center equations for a
 ```
 where primes indicate differentiation wrt $\psi$. In the case ``mod='gc_noK'``, the above equations are used with $K=0$.
 
-# Perturbed guiding center integration
+## Perturbed guiding center integration
 
 In the case of ``mode='gc_vac'`` we solve the guiding center equations under the vacuum assumption, i.e. $G =$ const. and $I = 0$.
 
@@ -193,7 +193,9 @@ In the case of ``mode='gc_vac'`` we solve the guiding center equations under the
 ```
 where $q$ is the charge, $m$ is the mass, and $v_\perp^2 = 2\mu B$.
 
-In the case of ``mode='gc'`` we solve the general guiding center equations for an MHD equilibrium:
+**Note:** the current implementation has no perturbed guiding-center RHS that retains a general $K(s,\theta,\zeta)$. For perturbed tracing, `mode='gc'` and `mode='gc_noK'` both evaluate the $K=0$ equations shown below; a full-$K$ equilibrium is silently treated as $K=0$ whenever a shear Alfvén wave perturbation is present. This differs from unperturbed tracing, where `mode='gc'` does retain the general $K$-dependent equations shown above.
+
+In the case of ``mode='gc'`` we solve the guiding center equations with $K=0$:
 ```math
    \dot{s} = \Bigg(-G \Phi_{,\theta}q + I\Phi_{,\zeta}q
                     + B qv_{||}(\alpha_{,\theta}G-\alpha_{,\zeta}I)
@@ -223,32 +225,32 @@ In the case of ``mode='gc'`` we solve the general guiding center equations for a
 
 ## Stopping criteria
 
-Guiding center integration is continued until the maximum integration time, `tmax`, is reached, or until one of the `StoppingCriteria` is hit. Stopping criteria include:
+Guiding center integration is continued until the maximum integration time, `tmax`, is reached, or until one of the `StoppingCriteria` is hit. All of these are imported from `firm3d.field.tracing`. Available stopping criteria include:
 - `MaxToroidalFluxStoppingCriterion`: stop when trajectory reaches a maximum value of normalized toroidal flux (e.g., $s=1$ indicates the plasma boundary)
-- `MinToroidalFluxStoppignCriterion`: stop when trajectory reaches a minimum value of normalized toroidal flux. Sometimes a point close to the axis, e.g. $s = 10^{-3}$, is chosen to avoid numerical issues associated with the coordinate singularity.
-- `ZetaStoppingCriterion`: stop when the toroidal angle reaches a given value (modulus $2\pi$).
-- `VparStoppingCriterion`: stop when the parallel velocity reaches a given value. For example, can be used to terminate tracing when a particle mirrors.
+- `MinToroidalFluxStoppingCriterion`: stop when trajectory reaches a minimum value of normalized toroidal flux. Sometimes a point close to the axis, e.g. $s = 10^{-3}$, is chosen to avoid numerical issues associated with the coordinate singularity.
 - `ToroidalTransitStoppingCriterion`: stop when the toroidal angle increases by an integer multiple of $2\pi$. Useful for resonance detection.
 - `IterationStoppingCriterion`: stop when a number of iterations is reached.
 - `StepSizeStoppingCriterion`: stop when the step size gets too small. When using adaptive timestepping, can avoid particles getting "stuck" due to small step size.
+
+To stop on a parallel-velocity crossing (e.g. when a particle mirrors), pass the target value(s) via the `vpars` argument to `trace_particles_boozer`/`trace_particles_boozer_perturbed` with `vpars_stop=True`, rather than a `StoppingCriterion` subclass; see [Trajectory saving](#trajectory-saving) below.
 
 ## Trajectory saving
 
 There are two ways the trajectory information can be saved: by recording "hits" of user-defined coordinate planes (e.g., Poincaré sections), or by recording uniform time intervals of the trajectory. The routines `trace_particles_boozer` or `trace_particles_boozer_perturbed` return this information in the tuple `(res_tys,res_hits)`.
 
 - If `forget_exact_path=False`, the parameter `dt_save` determines the time interval for trajectory saving. (Note that if this parameter is made too small, one may run into memory issues.) This trajectory information is returned in `res_tys`, which is a list (length = number of particles) of numpy arrays with shape `(nsave,5)`. Here `nsave` is the number of timesteps saved. Each row contains the time and the state, `[t, s, theta, zeta, v_par]`. If `forget_exact_path=True`, only the state at the initial and final time will be returned.
-- The "hits" are defined through the input lists `zetas`, `omegas`, `vpars`. If `vpars` is specified, the trajectory will be recorded when the parallel velocity hits a given value. For example, the Poincaré map for trapped particles is defined by recording the points with $v_{||} = 0$. If `zetas` is specified, the trajectory will be recorded when $\zeta - \omega t$ hits the values given in the `zetas` array, with the frequency $\omega$ given by the `omegas` array. The `zetas` and `omegas` lists must have same length. If `omegas` is not specified, it defaults to zeros. This feature is useful for defining the Poincaré map for passing particles (with or without a single-harmonic shear Alfvén wave). The hits are returned in `res_hits`, which is a list (length = number of particles) of numpy arrays with shape `(nhits,6)`, where `nhits` is the number of hits of a coordinate plane or stopping criteria. Each row or the array contains `[time] + [idx] + state`, where `idx` tells us which of the hit planes or stopping criteria was hit. If `idx>=0` and `idx<len(zetas)`, then the `zetas[idx]` plane was hit. If `idx>=len(zetas)`, then the `vpars[idx-len(zetas)]` plane was hit. If `idx<0`, then `stopping_criteria[int(-idx)-1]` was hit. The state vector is `[t, s, theta, zeta, v_par]`.
+- The "hits" are defined through the input lists `phases`, `n_zetas`, `m_thetas`, `omegas`, and `vpars`. If `phases` is specified, the trajectory will be recorded when $n_\zeta \zeta + m_\theta \theta - \omega t$ hits the values given in the `phases` array, with $n_\zeta$, $m_\theta$, and $\omega$ given elementwise by the `n_zetas`, `m_thetas`, and `omegas` arrays (all four lists must have the same length). This feature is useful for defining the Poincaré map for passing particles (with or without a single-harmonic shear Alfvén wave). If `vpars` is specified, the trajectory will be recorded when the parallel velocity hits a given value. For example, the Poincaré map for trapped particles is defined by recording the points with $v_{||} = 0$. The hits are returned in `res_hits`, which is a list (length = number of particles) of numpy arrays with shape `(nhits,6)`, where `nhits` is the number of hits of a coordinate plane or stopping criteria. Each row of the array contains `[time] + [idx] + state`, where `idx` tells us which of the hit planes or stopping criteria was hit. If `idx>=0` and `idx<len(phases)`, then the `phases[idx]` plane was hit. If `idx>=len(phases)`, then the `vpars[idx-len(phases)]` plane was hit. If `idx<0`, then `stopping_criteria[int(-idx)-1]` was hit. The state vector is `[s, theta, zeta, v_par]`.
 
 ## Magnetic axis handling
 
 The coordinate singularity at the magnetic axis can be handled in several ways using the keyword argument `axis` passed to
 `trace_particles_boozer` and `trace_particles_boozer_perturbed`.
 - If `axis=0`, the trajectory will be integrated in standard Boozer coordinates $(s,\theta,\zeta)$. If this is used, it is recommended that one passes a `MinToroidalFluxStoppingCriterion` to prevent particles from passing to $s < 0$.
-- If `axis=1`, the trajectory will be integrated in the pseudo-Cartesian coordinates $(\sqrt{s}\cos(\theta),\sqrt{s}\sin(\theta),\zeta)$, but all trajectory information will be saved in the standard Boozer coordinates $(s,\theta,\zeta)$. This option prevents particles from passing to $s < 0$. Because the equations of motion are mapped form $(s,\theta,\zeta)$ to $(\sqrt{s}\cos(\theta),\sqrt{s},\sin(\theta),\zeta)$, a division by $\sqrt{s}$ is performed. Thus this option may be ill-behaved near the axis.
+- If `axis=1`, the trajectory will be integrated in the pseudo-Cartesian coordinates $(\sqrt{s}\cos(\theta),\sqrt{s}\sin(\theta),\zeta)$, but all trajectory information will be saved in the standard Boozer coordinates $(s,\theta,\zeta)$. This option prevents particles from passing to $s < 0$. Because the equations of motion are mapped from $(s,\theta,\zeta)$ to $(\sqrt{s}\cos(\theta),\sqrt{s}\sin(\theta),\zeta)$, a division by $\sqrt{s}$ is performed. Thus this option may be ill-behaved near the axis.
 - If `axis=2`, the trajectory will be integrated in the pseudo-Cartesian coordinates $(s\cos(\theta),s\sin(\theta),\zeta)$, but all trajectory information will be saved in the standard Boozer coordinates $(s,\theta,\zeta)$. This option prevents particles from passing to $s < 0$. No division by $s$ is required to map to this coordinate system. This option is recommended if one would like to integrate near the magnetic axis.
 
 ## Solvers and solver options
 
 By default the Runge-Kutta Dormand-Prince 5(4) method implemented in [Boost](https://www.boost.org/doc/libs/1_54_0/boost/numeric/odeint/stepper/runge_kutta_dopri5.hpp) is used to integrate the ODEs. Adaptive time stepping is performed to satisfy the user-prescribed relative and absolute error tolerance parameters, `reltol` and `abstol`.
 
-If `solveSympl=True` in the `solver_options`, a symplectic solver is used with step size `dt`. The semi-implicit Euler scheme described in[Albert, C. G., et al. (2020). Symplectic integration with non-canonical quadrature for guiding-center orbits in magnetic confinement devices. Journal of computational physics, 403, 109065](https://doi.org/10.1016/j.jcp.2019.109065) is implemented. A root solve is performed to map from non-canonical to canonical variables, with tolerance given by `roottol`. If `predictor_step=True`, the initial guess for the next step is improved using first derivative information.
+If `ODE_solver="symplectic"` is passed to `trace_particles_boozer`, a symplectic solver is used with step size `dt`. The semi-implicit Euler scheme described in [Albert, C. G., et al. (2020). Symplectic integration with non-canonical quadrature for guiding-center orbits in magnetic confinement devices. Journal of computational physics, 403, 109065](https://doi.org/10.1016/j.jcp.2019.109065) is implemented. A root solve is performed to map from non-canonical to canonical variables, with tolerance given by `roottol`. If `predictor_step=True`, the initial guess for the next step is improved using first derivative information. A third option, `ODE_solver="dormand_prince"`, uses an alternative adaptive Dormand-Prince implementation with a configurable minimum timestep, `DP_hmin`.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -19,7 +19,12 @@ Magnetic Field Classes
 Trajectory Integration
 ----------------------
 
-.. automodule:: firm3d.field.trajectory_helpers
+.. automodule:: firm3d.field.tracing
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: firm3d.trajectory_helpers
    :members:
    :undoc-members:
    :show-inheritance:
@@ -27,11 +32,10 @@ Trajectory Integration
 Stopping Criteria
 -----------------
 
-# Note: This module may not exist yet in the current codebase
-# .. automodule:: firm3d.field.stopping_criteria
-#    :members:
-#    :undoc-members:
-#    :show-inheritance:
+Stopping criteria (``MaxToroidalFluxStoppingCriterion``,
+``MinToroidalFluxStoppingCriterion``, ``ToroidalTransitStoppingCriterion``,
+``IterationStoppingCriterion``, ``StepSizeStoppingCriterion``) are defined in
+``firm3d.field.tracing`` and documented above.
 
 Shear Alfvén Wave Classes
 -------------------------
@@ -95,7 +99,7 @@ Class Hierarchy
 .. inheritance-diagram:: firm3d.field.boozermagneticfield
    :parts: 1
 
-.. inheritance-diagram:: firm3d.field.trajectory_helpers
+.. inheritance-diagram:: firm3d.trajectory_helpers
    :parts: 1
 
 # .. inheritance-diagram:: firm3d.field.stopping_criteria

--- a/docs/guiding_center.rst
+++ b/docs/guiding_center.rst
@@ -5,9 +5,9 @@ Guiding center integration in Boozer coordinates is performed using equations of
 
 .. math::
 
-   L(\psi,\theta,\zeta,\rho_{||})  = q\left(\left[\psi + I  \rho_{||}\right] \dot{\theta} + \left[- \chi + G \rho_{||} \right] \dot{\zeta} + \rho_{||} K \dot{\psi}\right)  - \frac{\rho_{||}^2 B_0^2q^2}{2m} - \mu B_0
+   L(\psi,\theta,\zeta,\rho_{||})  = q\left(\left[\psi + I  \rho_{||}\right] \dot{\theta} + \left[- \chi + G \rho_{||} \right] \dot{\zeta} + \rho_{||} K \dot{\psi}\right)  - \frac{\rho_{||}^2 B^2q^2}{2m} - m\mu B
 
-where :math:`2\pi \psi` is the toroidal flux, :math:`2\pi \chi` is the poloidal flux, :math:`q` is the charge, :math:`m` is the mass, :math:`\rho_{||} = q v_{||}/(m B)` and the covariant form of the magnetic field is:
+where :math:`2\pi \psi` is the toroidal flux, :math:`2\pi \chi` is the poloidal flux, :math:`q` is the charge, :math:`m` is the mass, :math:`\rho_{||} = m v_{||}/(q B)`, :math:`\mu = v_\perp^2/(2B)` is the magnetic moment per unit mass (so that :math:`m\mu B = \tfrac{1}{2}mv_\perp^2`, matching the convention used throughout the rest of this page), and the covariant form of the magnetic field is:
 
 .. math::
 
@@ -15,7 +15,7 @@ where :math:`2\pi \psi` is the toroidal flux, :math:`2\pi \chi` is the poloidal 
 
 See R. White, Theory of Tokamak Plasmas, Sec. 3.2.
 
-The trajectory information is saved as :math:`(s,\theta,\zeta,v_{||})`, where :math:`s = \psi_0` is the toroidal flux normalized to its value on the boundary, :math:`2\pi\psi_0`.
+The trajectory information is saved as :math:`(s,\theta,\zeta,v_{||})`, where :math:`s = \psi/\psi_0` is the toroidal flux normalized to its (signed) value on the boundary, :math:`2\pi\psi_0`.
 
 Unperturbed Guiding Center Integration
 --------------------------------------
@@ -91,7 +91,16 @@ where :math:`q` is the charge, :math:`m` is the mass, and :math:`v_\perp^2 = 2\m
 General Mode (gc)
 ~~~~~~~~~~~~~~~~~
 
-In the case of ``mode='gc'`` we solve the general guiding center equations for an MHD equilibrium:
+.. note::
+   The current implementation has no perturbed guiding-center RHS that
+   retains a general :math:`K(s,\theta,\zeta)`. For perturbed tracing,
+   ``mode='gc'`` and ``mode='gc_noK'`` both evaluate the :math:`K=0` equations
+   shown below; a full-:math:`K` equilibrium is silently treated as
+   :math:`K=0` whenever a shear Alfvén wave perturbation is present. This
+   differs from unperturbed tracing, where ``mode='gc'`` does retain the
+   general :math:`K`-dependent equations shown in the previous section.
+
+In the case of ``mode='gc'`` we solve the guiding center equations with :math:`K=0`:
 
 .. math::
 

--- a/docs/magnetic_axis.rst
+++ b/docs/magnetic_axis.rst
@@ -10,7 +10,10 @@ If ``axis=0``, the trajectory will be integrated in standard Boozer coordinates 
 
 .. code-block:: python
 
-   from firm3d.field.trajectory_helpers import MinToroidalFluxStoppingCriterion
+   from firm3d.field.tracing import (
+       MinToroidalFluxStoppingCriterion,
+       MaxToroidalFluxStoppingCriterion,
+   )
 
    # Use standard Boozer coordinates
    res_tys, res_hits = trace_particles_boozer(
@@ -25,7 +28,7 @@ If ``axis=0``, the trajectory will be integrated in standard Boozer coordinates 
 Pseudo-Cartesian Coordinates (axis=1)
 -------------------------------------
 
-If ``axis=1``, the trajectory will be integrated in the pseudo-Cartesian coordinates :math:`(\sqrt{s}\cos(\theta),\sqrt{s}\sin(\theta),\zeta)`, but all trajectory information will be saved in the standard Boozer coordinates :math:`(s,\theta,\zeta)`. This option prevents particles from passing to :math:`s < 0`. Because the equations of motion are mapped from :math:`(s,\theta,\zeta)` to :math:`(\sqrt{s}\cos(\theta),\sqrt{s},\sin(\theta),\zeta)`, a division by :math:`\sqrt{s}` is performed. Thus this option may be ill-behaved near the axis.
+If ``axis=1``, the trajectory will be integrated in the pseudo-Cartesian coordinates :math:`(\sqrt{s}\cos(\theta),\sqrt{s}\sin(\theta),\zeta)`, but all trajectory information will be saved in the standard Boozer coordinates :math:`(s,\theta,\zeta)`. This option prevents particles from passing to :math:`s < 0`. Because the equations of motion are mapped from :math:`(s,\theta,\zeta)` to :math:`(\sqrt{s}\cos(\theta),\sqrt{s}\sin(\theta),\zeta)`, a division by :math:`\sqrt{s}` is performed. Thus this option may be ill-behaved near the axis.
 
 .. code-block:: python
 

--- a/docs/magnetic_fields.rst
+++ b/docs/magnetic_fields.rst
@@ -9,7 +9,7 @@ Overview
 An important attribute of ``BoozerMagneticField`` classes is ``field_type``, which can be:
 
 - ``vac`` (vacuum field)
-- ``no_k`` (does not retain the radial covariant component)
+- ``nok`` (does not retain the radial covariant component)
 - Empty string (no assumptions made)
 
 By default, the ``field_type`` will determine the ``mode`` used for guiding center tracing: ``gc_vac``, ``gc_noK``, or ``gc``.
@@ -29,9 +29,9 @@ The covariant components of equilibrium field are:
 
 .. math::
 
-   G(s) = G_0 + \sqrt{2s\psi_0/\overline{B}} G_1
+   G(s) = G_0 + s G_1
 
-   I(s) = I_0 + \sqrt{2s\psi_0/\overline{B}} I_1
+   I(s) = I_0 + s I_1
 
    K(s,\theta,\zeta) = \sqrt{2s\psi_0/\overline{B}} K_1 \sin(\theta - N \zeta)
 
@@ -39,9 +39,9 @@ And the rotational transform is:
 
 .. math::
 
-   \iota(s) = \iota_0
+   \iota(s) = \iota_0 + s \iota_1
 
-While formally :math:`I_0 = I_1 = G_1 = K_1 = 0`, these terms have been included in order to test the guiding center equations at finite beta.
+While formally :math:`I_0 = I_1 = G_1 = K_1 = \iota_1 = 0`, these terms have been included in order to test the guiding center equations at finite beta.
 
 Usage Example
 ~~~~~~~~~~~~~
@@ -52,18 +52,19 @@ Usage Example
 
    # Create an analytic Boozer field
    field = BoozerAnalytic(
+       etabar=0.1,
        B0=1.0,
-       eta_bar=0.1,
        N=3,
-       B0z=0.01,
-       m=2,
-       n=1,
        G0=1.0,
-       G1=0.0,
+       psi0=0.1,
+       iota0=0.5,
        I0=0.0,
+       G1=0.0,
        I1=0.0,
        K1=0.0,
-       iota0=0.5
+       B0z=[0.01],
+       m=[2],
+       n=[1],
    )
 
 BoozerRadialInterpolant
@@ -73,7 +74,7 @@ The magnetic field can be computed at any point in Boozer coordinates using radi
 
 If given a ``VMEC`` output file, performs a Boozer coordinate transformation using ``booz_xform``. If given a ``booz_xform`` output file, the Boozer transformation must be performed with all surfaces on the VMEC half grid, and with ``phip``, ``chi``, ``pres``, and ``phi`` saved in the file.
 
-Field evaluations are parallelized over the number of Fourier harmonics over CPUs, given the communicator ``comm``. In addition, the evaluations are parallelized over threads with OpenMP. Because the guiding center tracing routines are also parallelized over CPUs with MPI, we don't recommend passing ``comm`` to ``BoozerRadialInterpolant`` if it is being passed to a tracing routine.
+The one-time setup (computing Fourier coefficients of ``K`` and building splines) is parallelized over evaluation-grid points across CPUs, given the communicator ``comm``, with the resulting splines then broadcast to all ranks. Field evaluations themselves are parallelized over points with OpenMP. Because the guiding center tracing routines are also parallelized over CPUs with MPI, we don't recommend passing ``comm`` to ``BoozerRadialInterpolant`` if it is being passed to a tracing routine.
 
 .. note::
    For most use cases, it is recommended to use ``InterpolatedBoozerField.from_booz_xform()`` instead of creating a ``BoozerRadialInterpolant``. The ``from_booz_xform()`` method provides a more convenient interface (through the ``BoozerSplineField`` class) and is the preferred approach in most examples.
@@ -117,7 +118,7 @@ Key features:
 
 - Interpolates on the VMEC grid with user-specified angular resolution
 - Supports quasisymmetry enforcement through ``helicity_M`` and ``helicity_N`` parameters
-- Can enforce vacuum field assumptions or exclude the K component
+- Can enforce vacuum field assumptions or exclude the K component; note that ``no_K`` defaults to ``True`` (unlike ``BoozerRadialInterpolant``, where it defaults to ``False``), so the K component is excluded unless ``no_K=False`` is passed explicitly
 - Supports parallel computation via MPI communicator
 
 Usage Example
@@ -175,7 +176,7 @@ InterpolatedBoozerField
 
 This field interpolates a magnetic field on a regular grid in :math:`(s,\theta,\zeta)`. This resulting interpolant can then be evaluated very quickly inside the tracing loop.
 
-The recommended way to create an ``InterpolatedBoozerField`` from a ``booz_xform`` output file is using the ``from_booz_xform`` class method, which automatically handles the Boozer coordinate transformation and interpolation setup.
+The recommended way to create an ``InterpolatedBoozerField`` from a ``booz_xform`` output file is using the ``from_booz_xform`` class method, which automatically handles the Boozer coordinate transformation and interpolation setup. Note that ``from_booz_xform`` also defaults to ``no_K=True``, excluding the K component unless ``no_K=False`` is passed explicitly.
 
 Usage Example (Recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -244,7 +245,7 @@ All magnetic field classes provide methods to evaluate the field at given points
    field.set_points(points)
 
    # Now evaluate field quantities
-   B = field.B()  # magnetic field magnitude
+   B = field.modB()  # magnetic field magnitude
    G = field.G()  # G component
    I = field.I()  # I component
    K = field.K()  # K component
@@ -252,4 +253,4 @@ All magnetic field classes provide methods to evaluate the field at given points
    # For single point evaluation
    single_point = np.array([[0.5, 0.0, 0.0]])  # shape (1, 3)
    field.set_points(single_point)
-   B_single = field.B()[0]  # get first (and only) value
+   B_single = field.modB()[0]  # get first (and only) value

--- a/docs/poincare_maps.rst
+++ b/docs/poincare_maps.rst
@@ -27,7 +27,7 @@ The ``TrappedPoincare`` class computes Poincaré maps for trapped particles that
 
 .. code-block:: python
 
-    from firm3d.field.trajectory_helpers import TrappedPoincare
+    from firm3d.trajectory_helpers import TrappedPoincare
     from firm3d.util.constants import (
         ALPHA_PARTICLE_MASS,
         ALPHA_PARTICLE_CHARGE,
@@ -57,8 +57,7 @@ The ``TrappedPoincare`` class computes Poincaré maps for trapped particles that
         ns_poinc=120,      # number of s initial conditions
         neta_poinc=5,      # number of eta initial conditions
         Nmaps=1000,        # number of return maps
-        reltol=1e-8,       # Relative tolerance
-        abstol=1e-8,       # Absolute tolerance
+        solver_options={"reltol": 1e-8, "abstol": 1e-8},
         tmax=1e-3,
     )
 
@@ -87,7 +86,7 @@ The ``PassingPoincare`` class computes Poincaré maps for passing particles in u
 
 .. code-block:: python
 
-    from firm3d.field.trajectory_helpers import PassingPoincare
+    from firm3d.trajectory_helpers import PassingPoincare
     from firm3d.util.constants import (
         ALPHA_PARTICLE_MASS,
         ALPHA_PARTICLE_CHARGE,
@@ -105,8 +104,7 @@ The ``PassingPoincare`` class computes Poincaré maps for passing particles in u
         ns_poinc=120,      # number of s initial conditions
         ntheta_poinc=1,    # number of theta initial conditions
         Nmaps=1000,        # number of return maps
-        reltol=1e-8,       # Relative tolerance
-        abstol=1e-8,       # Absolute tolerance
+        solver_options={"reltol": 1e-8, "abstol": 1e-8},
     )
 
     # Plot the Poincaré map
@@ -134,7 +132,8 @@ The ``PassingPerturbedPoincare`` class computes Poincaré maps for passing parti
 
 .. code-block:: python
 
-    from firm3d.field.trajectory_helpers import PassingPerturbedPoincare
+    from firm3d.trajectory_helpers import PassingPerturbedPoincare
+    from firm3d.field import ShearAlfvenHarmonic
     from firm3d.util.constants import (
         ALPHA_PARTICLE_MASS,
         ALPHA_PARTICLE_CHARGE,
@@ -144,7 +143,7 @@ The ``PassingPerturbedPoincare`` class computes Poincaré maps for passing parti
     # Create shear Alfvén wave perturbation
     Phihat = -1.50119e3
     saw = ShearAlfvenHarmonic(
-        Phihat, m=1, n=1, omega=136041, phase=0, B0=field
+        Phihat, Phim=1, Phin=1, omega=136041, phase=0, B0=field
     )
 
     # Point for evaluation of Eprime
@@ -164,8 +163,7 @@ The ``PassingPerturbedPoincare`` class computes Poincaré maps for passing parti
         ns_poinc=120,      # number of s initial conditions
         nchi_poinc=1,      # number of chi initial conditions
         Nmaps=1000,        # number of return maps
-        reltol=1e-8,       # Relative tolerance
-        abstol=1e-8,       # Absolute tolerance
+        solver_options={"reltol": 1e-8, "abstol": 1e-8},
     )
 
     # Plot the Poincaré map
@@ -194,7 +192,7 @@ All Poincaré map classes provide methods to access the computed data and create
     s_all, chis_all, etas_all, t_all = poinc.get_poincare_data()
 
     # Get Poincaré map data for passing particles (perturbed)
-    s_all, chis_all, etas_all, vpars_all, t_all = poinc.get_poincare_data()
+    s_all, chis_all, etas_all, vpars_all, t_all, DA_all, DA_times = poinc.get_poincare_data()
 
 **Return Values:**
 
@@ -204,6 +202,7 @@ All Poincaré map classes provide methods to access the computed data and create
 - **etas_all**: List of lists containing mapping angle η at each return (trapped/perturbed)
 - **vpars_all**: List of lists containing parallel velocity v_|| at each return (passing)
 - **t_all**: List of lists containing time at each return
+- **DA_all**, **DA_times** (perturbed passing only): perturbed vector potential parameter :math:`\alpha` and its evaluation times along each trajectory
 
 **Visualization:**
 
@@ -241,23 +240,30 @@ All classes support MPI parallelization for large-scale computations:
     )
 
 **Solver Options:**
-Tune ODE solver parameters for accuracy vs. speed:
+Solver parameters are not passed directly as constructor keyword arguments;
+they are collected in a ``solver_options`` dict, which is forwarded to the
+underlying ``trace_particles_boozer``/``trace_particles_boozer_perturbed``
+call. Tune them for accuracy vs. speed:
 
 .. code-block:: python
 
     # For adaptive solver (default)
     poinc = PassingPoincare(
         field, lam, sign_vpar, mass, charge, Ekin,
-        reltol=1e-8,    # relative tolerance
-        abstol=1e-8,    # absolute tolerance
+        solver_options={
+            "reltol": 1e-8,   # relative tolerance
+            "abstol": 1e-8,   # absolute tolerance
+        },
         # ... other parameters
     )
 
     # For symplectic solver
     poinc = PassingPoincare(
         field, lam, sign_vpar, mass, charge, Ekin,
-        solveSympl=True,  # Enable symplectic solver
-        dt=1e-8,         # Fixed step size
-        roottol=1e-10,   # Root finding tolerance
+        solver_options={
+            "ODE_solver": "symplectic",  # Enable symplectic solver
+            "dt": 1e-8,                  # Fixed step size
+            "roottol": 1e-10,            # Root finding tolerance
+        },
         # ... other parameters
     )

--- a/docs/shear_alfven_waves.rst
+++ b/docs/shear_alfven_waves.rst
@@ -5,7 +5,7 @@ Given an equilibrium field :math:`\textbf{B}_0`, a shear Alfvén wave is modeled
 
 .. math::
 
-   \delta \textbf{E} = -\nabla \Phi - \frac{\partial \alpha}{\partial t}
+   \delta \textbf{E} = -\nabla \Phi - B_0 \frac{\partial \alpha}{\partial t}
 
    \delta \textbf{B} = \nabla \times \left(\alpha \textbf{B}_0 \right)
 
@@ -42,7 +42,7 @@ A single float value representing a uniform amplitude across all radial position
 
    # Uniform amplitude across all s
    Phihat = 0.01
-   saw = ShearAlfvenHarmonic(Phihat, m=2, n=1, omega=1.0, phase=0.0, B0=field)
+   saw = ShearAlfvenHarmonic(Phihat, Phim=2, Phin=1, omega=1.0, phase=0.0, B0=field)
 
 **2. Varying Profile (Tabulated)**
 A tuple of two lists defining the radial dependence: `(s_values, Phihat_values)`:
@@ -56,12 +56,15 @@ A tuple of two lists defining the radial dependence: `(s_values, Phihat_values)`
    # Create wave with varying profile
    saw = ShearAlfvenHarmonic(
        (s_values, Phihat_values),
-       m=2, n=1, omega=1.0, phase=0.0, B0=field
+       Phim=2, Phin=1, omega=1.0, phase=0.0, B0=field
    )
 
 .. note::
    The `s_values` must be in the range [0, 1] and will be automatically sorted.
-   For non-zero poloidal mode numbers (m ≠ 0), the profile is automatically set to zero at s = 0.
+   For non-zero poloidal mode numbers (m ≠ 0), if the profile does not already
+   include a point at s = 0, one is inserted with :math:`\hat{\Phi}=0` (the
+   expected boundary condition at the axis for m ≠ 0). A value explicitly
+   provided at s = 0 is not overridden.
 
 Usage Example
 ~~~~~~~~~~~~~
@@ -72,7 +75,7 @@ Usage Example
    import numpy as np
 
    # Create equilibrium field
-   eq_field = BoozerAnalytic(B0=1.0, iota0=0.5)
+   eq_field = BoozerAnalytic(etabar=0.1, B0=1.0, N=0, G0=1.0, psi0=0.1, iota0=0.5)
 
    # Define radial profile (constant amplitude)
    Phihat = 0.01
@@ -80,8 +83,8 @@ Usage Example
    # Create shear Alfvén wave
    saw = ShearAlfvenHarmonic(
        Phihat,  # radial profile amplitude
-       m=2,     # poloidal mode number
-       n=1,     # toroidal mode number
+       Phim=2,     # poloidal mode number
+       Phin=1,     # toroidal mode number
        omega=1.0,  # frequency
        phase=0.0,  # phase shift
        B0=eq_field  # equilibrium field
@@ -108,17 +111,17 @@ Usage Example
    Phihat1 = 0.01
 
    wave1 = ShearAlfvenHarmonic(
-       Phihat1, m=2, n=1, omega=1.0, phase=0.0, B0=eq_field
+       Phihat1, Phim=2, Phin=1, omega=1.0, phase=0.0, B0=eq_field
    )
 
-   # Create superposition
-   saw_super = ShearAlfvenWavesSuperposition(wave1)
+   # Create superposition (constructor takes a list of waves)
+   saw_super = ShearAlfvenWavesSuperposition([wave1])
 
    # Add additional waves
    Phihat2 = 0.005
 
    wave2 = ShearAlfvenHarmonic(
-       Phihat2, m=3, n=1, omega=1.5, phase=0.0, B0=eq_field
+       Phihat2, Phim=3, Phin=1, omega=1.5, phase=0.0, B0=eq_field
    )
 
    saw_super.add_wave(wave2)
@@ -129,8 +132,9 @@ InterpolatedShearAlfvenWave
 ``InterpolatedShearAlfvenWave`` accelerates evaluation of wave quantities by
 interpolating a ``ShearAlfvenWave`` or ``ShearAlfvenWavesSuperposition`` on a
 regular grid in :math:`(s,\theta,\zeta)` using the C++ ``RegularGridInterpolant3D``.
-The interpolant is built at :math:`t=0`; time dependence is restored at
-evaluation time. Use it in tracing loops where repeated wave evaluations dominate
+The interpolant is built by sampling each quantity at two reference times
+(:math:`t=0` and a quarter-period offset) and reconstructing the full time
+dependence at evaluation time via trigonometric identities. Use it in tracing loops where repeated wave evaluations dominate
 runtime, especially for a large number of harmonics. 
 
 Usage Example 
@@ -204,4 +208,4 @@ ShearAlfvenWave classes provide methods to evaluate the perturbed fields. First,
    # For single point evaluation
    single_point = np.array([[0.5, 0.0, 0.0, 0.0]])  # shape (1, 4)
    saw.set_points(single_point)
-   phi_single = saw.phi()[0]  # get first (and only) value
+   phi_single = saw.Phi()[0]  # get first (and only) value

--- a/docs/solvers.rst
+++ b/docs/solvers.rst
@@ -25,7 +25,7 @@ The default solver uses the Runge-Kutta Dormand-Prince 5(4) method with adaptive
 Symplectic Solver
 -----------------
 
-If ``solveSympl=True``, a symplectic solver is used with step size ``dt``. The semi-implicit Euler scheme described in Albert, C. G., et al. (2020). Symplectic integration with non-canonical quadrature for guiding-center orbits in magnetic confinement devices. Journal of computational physics, 403, 109065 is implemented. A root solve is performed to map from non-canonical to canonical variables, with tolerance given by ``roottol``. If ``predictor_step=True``, the initial guess for the next step is improved using first derivative information.
+If ``ODE_solver="symplectic"``, a symplectic solver is used with step size ``dt``. The semi-implicit Euler scheme described in Albert, C. G., et al. (2020). Symplectic integration with non-canonical quadrature for guiding-center orbits in magnetic confinement devices. Journal of computational physics, 403, 109065 is implemented. A root solve is performed to map from non-canonical to canonical variables, with tolerance given by ``roottol``. If ``predictor_step=True`` (the default when ``ODE_solver="symplectic"``), the initial guess for the next step is improved using first derivative information.
 
 .. code-block:: python
 
@@ -35,11 +35,19 @@ If ``solveSympl=True``, a symplectic solver is used with step size ``dt``. The s
        stz_inits=points,
        parallel_speeds=vpars,
        tmax=1e-3,
-       solveSympl=True,      # Enable symplectic solver
+       ODE_solver="symplectic",  # Enable symplectic solver
        dt=1e-8,              # Fixed step size
        roottol=1e-10,        # Root finding tolerance
        predictor_step=True    # Use predictor step
    )
+
+Dormand-Prince Solver
+---------------------
+
+A third option, ``ODE_solver="dormand_prince"``, uses an alternative adaptive
+Dormand-Prince implementation. It accepts a ``DP_hmin`` parameter (default
+``0.0``): if the adaptive step size drops below ``DP_hmin``, the stepper
+completes the step using ``DP_hmin`` instead.
 
 Solver Options Reference
 ------------------------
@@ -47,7 +55,7 @@ Solver Options Reference
 Default Solver Options
 ~~~~~~~~~~~~~~~~~~~~~~
 
-The default solver (``solveSympl=False``) uses adaptive timestepping with these parameters:
+The default solver (``ODE_solver="boost"``) uses adaptive timestepping with these parameters:
 
 - **reltol**: Relative tolerance for adaptive timestepping (default: 1e-9)
 - **abstol**: Absolute tolerance for adaptive timestepping (default: 1e-9)
@@ -55,8 +63,8 @@ The default solver (``solveSympl=False``) uses adaptive timestepping with these 
 Symplectic Solver Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For the symplectic solver (``solveSympl=True``), use these parameters:
+For the symplectic solver (``ODE_solver="symplectic"``), use these parameters:
 
-- **dt**: Fixed step size (required, typically 1e-8)
-- **roottol**: Root finding tolerance (typically 1e-10)
-- **predictor_step**: Use predictor step for better convergence (True)
+- **dt**: Fixed step size (default: 1e-7 if not specified; typically set explicitly, e.g. 1e-8)
+- **roottol**: Root finding tolerance (defaults to ``tol``; typically 1e-10)
+- **predictor_step**: Use predictor step for better convergence (defaults to True for this solver)

--- a/docs/stopping_criteria.rst
+++ b/docs/stopping_criteria.rst
@@ -13,7 +13,7 @@ Stop when trajectory reaches a maximum value of normalized toroidal flux (e.g., 
 
 .. code-block:: python
 
-   from firm3d.field.trajectory_helpers import MaxToroidalFluxStoppingCriterion
+   from firm3d.field.tracing import MaxToroidalFluxStoppingCriterion
 
    # Stop when s >= 1.0 (plasma boundary)
    stopping_criteria = [MaxToroidalFluxStoppingCriterion(1.0)]
@@ -25,34 +25,10 @@ Stop when trajectory reaches a minimum value of normalized toroidal flux. When `
 
 .. code-block:: python
 
-   from firm3d.field.trajectory_helpers import MinToroidalFluxStoppingCriterion
+   from firm3d.field.tracing import MinToroidalFluxStoppingCriterion
 
    # Stop when s <= 0.001 (close to magnetic axis)
    stopping_criteria = [MinToroidalFluxStoppingCriterion(0.001)]
-
-ZetaStoppingCriterion
-~~~~~~~~~~~~~~~~~~~~~
-
-Stop when the toroidal angle reaches a given value (modulus :math:`2\pi`).
-
-.. code-block:: python
-
-   from firm3d.field.trajectory_helpers import ZetaStoppingCriterion
-
-   # Stop when zeta reaches pi/2 (mod 2*pi)
-   stopping_criteria = [ZetaStoppingCriterion(np.pi/2)]
-
-VparStoppingCriterion
-~~~~~~~~~~~~~~~~~~~~~
-
-Stop when the parallel velocity reaches a given value. For example, can be used to terminate tracing when a particle mirrors.
-
-.. code-block:: python
-
-   from firm3d.field.trajectory_helpers import VparStoppingCriterion
-
-   # Stop when v_parallel changes sign (mirroring)
-   stopping_criteria = [VparStoppingCriterion(0.0)]
 
 ToroidalTransitStoppingCriterion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -61,7 +37,7 @@ Stop when the toroidal angle increases by an integer multiple of :math:`2\pi`. U
 
 .. code-block:: python
 
-   from firm3d.field.trajectory_helpers import ToroidalTransitStoppingCriterion
+   from firm3d.field.tracing import ToroidalTransitStoppingCriterion
 
    # Stop after 5 toroidal transits
    stopping_criteria = [ToroidalTransitStoppingCriterion(5)]
@@ -73,7 +49,7 @@ Stop when a number of iterations is reached. This is useful for terminating long
 
 .. code-block:: python
 
-   from firm3d.field.trajectory_helpers import IterationStoppingCriterion
+   from firm3d.field.tracing import IterationStoppingCriterion
 
    # Stop after 10000 integration steps
    stopping_criteria = [IterationStoppingCriterion(10000)]
@@ -85,10 +61,17 @@ Stop when the step size gets too small. When using adaptive timestepping, can av
 
 .. code-block:: python
 
-   from firm3d.field.trajectory_helpers import StepSizeStoppingCriterion
+   from firm3d.field.tracing import StepSizeStoppingCriterion
 
    # Stop when step size < 1e-10
    stopping_criteria = [StepSizeStoppingCriterion(1e-10)]
+
+.. warning::
+   The Python binding for ``StepSizeStoppingCriterion`` currently declares its
+   argument as a C++ ``double`` while the underlying class stores it as an
+   ``int``, so any fractional value (e.g. ``1e-10``) is silently truncated to
+   ``0`` and the criterion never triggers. This is a known bug, tracked
+   separately from this documentation.
 
 Usage Examples
 --------------
@@ -101,27 +84,30 @@ You can combine multiple stopping criteria to create robust integration conditio
 .. code-block:: python
 
    from firm3d.field.tracing import (
+       trace_particles_boozer,
        MaxToroidalFluxStoppingCriterion,
        MinToroidalFluxStoppingCriterion,
-       VparStoppingCriterion,
-       IterationStoppingCriterion
+       IterationStoppingCriterion,
    )
 
    # Combine multiple criteria
    stopping_criteria = [
        MaxToroidalFluxStoppingCriterion(1.0),    # Stop at boundary
        MinToroidalFluxStoppingCriterion(0.001),  # Stop near axis
-       VparStoppingCriterion(0.0),               # Stop at mirror points
        IterationStoppingCriterion(50000)         # Stop after max iterations
    ]
 
-   # Use in tracing
+   # Use in tracing. Stopping on a parallel-velocity crossing (e.g. mirror
+   # points) is not a StoppingCriterion subclass -- pass the target value(s)
+   # via `vpars` and set `vpars_stop=True` instead.
    res_tys, res_hits = trace_particles_boozer(
        field=field,
        stz_inits=points,
-       parallel_speeds=vpars,
+       parallel_speeds=parallel_speeds,
        tmax=1e-3,
-       stopping_criteria=stopping_criteria
+       stopping_criteria=stopping_criteria,
+       vpars=[0.0],       # stop when v_parallel crosses zero (mirroring)
+       vpars_stop=True,
    )
 
 Interpreting Results
@@ -132,11 +118,13 @@ When stopping criteria are hit, the information is returned in the ``res_hits`` 
 - **time**: Time when the criterion was hit
 - **idx**: Index indicating which criterion was hit
 
-  - If ``idx >= 0`` and ``idx < len(zetas)``: the ``zetas[idx]`` plane was hit
-  - If ``len(vpars)+len(zetas)>idx>=len(zetas)``: the ``vpars[idx-len(zetas)]`` plane was hit
-  - If ``idx >= len(vpars)+len(zetas)``: the ``thetas[idx-len(vpars)-len(zetas)]`` plane was hit
+  - If ``idx >= 0`` and ``idx < len(phases)``: the ``phases[idx]`` plane was hit,
+    i.e. ``n_zetas[idx]*zeta + m_thetas[idx]*theta - omegas[idx]*t`` crossed
+    ``phases[idx]``
+  - If ``len(vpars)+len(phases) > idx >= len(phases)``: the
+    ``vpars[idx-len(phases)]`` value was crossed
   - If ``idx < 0``: ``stopping_criteria[int(-idx)-1]`` was hit
-- **state**: The state vector ``[t, s, theta, zeta, v_parallel]``
+- **state**: The state vector ``[s, theta, zeta, v_parallel]``
 
 .. code-block:: python
 

--- a/docs/trajectory_saving.rst
+++ b/docs/trajectory_saving.rst
@@ -42,19 +42,18 @@ The "hits" are defined through the input lists ``phases``, ``n_zetas``, ``m_thet
 
 - **vpars**: If specified, the trajectory will be recorded when the parallel velocity hits a given value. For example, the Poincaré map for trapped particles is defined by recording the points with :math:`v_{||} = 0`.
 
-- **phases**, **n_zetas**, **m_zetas** and **omegas**: If ``phases`` is specified, the trajectory will be recorded when :math:`n_\zeta * \zeta + m_\theta * theta - \omega t` hits the values given in the ``phases`` array, with the frequency :math:`\omega` given by the ``omegas`` array. All lists must have the same length.
+- **phases**, **n_zetas**, **m_thetas** and **omegas**: If ``phases`` is specified, the trajectory will be recorded when :math:`n_\zeta \zeta + m_\theta \theta - \omega t` hits the values given in the ``phases`` array, with :math:`n_\zeta`, :math:`m_\theta`, and :math:`\omega` given elementwise by the ``n_zetas``, ``m_thetas``, and ``omegas`` arrays. All four lists must have the same length.
 
 
 **Hit Data Structure:**
 
 The hits are returned in ``res_hits``, which is a list (length = number of particles) of numpy arrays with shape ``(nhits,6)``, where ``nhits`` is the number of hits of a coordinate plane or stopping criteria. Each row of the array contains ``[time] + [idx] + state]``, where ``idx`` tells us which of the hit planes or stopping criteria was hit:
 
-- If ``idx >= 0`` and ``idx < len(zetas)``: the ``zetas[idx]`` plane was hit
-- If ``len(zetas) <= idx < len(zetas) + len(vpars)``: the ``vpars[idx-len(zetas)]`` plane was hit
-- If ``len(zetas) + len(vpars) <= idx < len(zetas) + len(vpars) + len(thetas)``: the ``thetas[idx-len(zetas)-len(vpars)]`` plane was hit
+- If ``idx >= 0`` and ``idx < len(phases)``: the ``phases[idx]`` plane was hit
+- If ``len(phases) <= idx < len(phases) + len(vpars)``: the ``vpars[idx-len(phases)]`` value was hit
 - If ``idx < 0``: ``stopping_criteria[int(-idx)-1]`` was hit
 
-The state vector is ``[t, s, theta, zeta, v_par]``.
+The state vector is ``[s, theta, zeta, v_par]``.
 
 Multiple Hit Planes
 -------------------
@@ -63,16 +62,14 @@ For custom analysis beyond the standard Poincaré maps, you can specify multiple
 
 .. code-block:: python
 
-   # Record hits at multiple toroidal angles
-   zetas = [0.0, np.pi/2, np.pi, 3*np.pi/2]
-   omega_zetas = [0.0, 0.0, 0.0, 0.0]
-
-   # Record hits at multiple poloidal angles
-   thetas = [0.0, np.pi/2]
-   omega_thetas = [0.0, 0.0]
+   # Record hits when zeta - omega*t crosses each of these 4 values
+   phases = [0.0, np.pi/2, np.pi, 3*np.pi/2]
+   n_zetas = [1.0, 1.0, 1.0, 1.0]
+   m_thetas = [0.0, 0.0, 0.0, 0.0]
+   omegas = [0.0, 0.0, 0.0, 0.0]
 
    # Record hits at multiple parallel velocities
-   vpars = [0.0, 0.5, -0.5]
+   vpar_hits = [0.0, 0.5, -0.5]
 
    res_tys, res_hits = trace_particles_boozer(
        field=field,
@@ -83,23 +80,20 @@ For custom analysis beyond the standard Poincaré maps, you can specify multiple
        n_zetas=n_zetas,
        m_thetas=m_thetas,
        omegas=omegas,
-       vpars=vpars
+       vpars=vpar_hits
    )
 
    # Analyze hits
    hits = res_hits[0]
    for hit in hits:
        time, idx, s, theta, zeta, vpar = hit
-       if idx < len(zetas):
-           print(f"Hit zeta plane {idx} at t={time:.3f}")
-       elif idx < len(zetas) + len(vpars):
-           vpar_idx = idx - len(zetas)
-           print(f"Hit v_parallel plane {vpar_idx} at t={time:.3f}")
-       elif idx < len(zetas) + len(vpars) + len(thetas):
-           theta_idx = idx - len(zetas) - len(vpars)
-           print(f"Hit theta plane {theta_idx} at t={time:.3f}")
-       else:
+       if idx < 0:
            print(f"Hit stopping criterion at t={time:.3f}")
+       elif idx < len(phases):
+           print(f"Hit phase plane {int(idx)} at t={time:.3f}")
+       else:
+           vpar_idx = int(idx) - len(phases)
+           print(f"Hit v_parallel plane {vpar_idx} at t={time:.3f}")
 
 Memory Management
 -----------------

--- a/src/firm3d/field/boozermagneticfield.py
+++ b/src/firm3d/field/boozermagneticfield.py
@@ -628,19 +628,19 @@ class BoozerAnalytic(BoozerMagneticField):
     the covariant components of equilibrium field are,
 
     .. math::
-        G(s) = G_0 + \sqrt{2s\psi_0/\overline{B}} G_1
+        G(s) = G_0 + s G_1
 
-        I(s) = I_0 + \sqrt{2s\psi_0/\overline{B}} I_1
+        I(s) = I_0 + s I_1
 
         K(s,\theta,\zeta) = \sqrt{2s\psi_0/\overline{B}} K_1 \sin(\theta - N \zeta),
 
     and the rotational transform is,
 
     .. math::
-        \iota(s) = \iota_0.
+        \iota(s) = \iota_0 + s \iota_1.
 
-    While formally :math:`I_0 = I_1 = G_1 = K_1 = 0`, these terms have been included
-    in order to test the guiding center equations at finite beta.
+    While formally :math:`I_0 = I_1 = G_1 = K_1 = \iota_1 = 0`, these terms have
+    been included in order to test the guiding center equations at finite beta.
 
     Args:
         etabar: magnitude of first order correction to magnetic field strength
@@ -654,6 +654,7 @@ class BoozerAnalytic(BoozerMagneticField):
         G1: first order correction to toroidal covariant component (defaults to 0)
         I1: first order correction to poloidal covariant component (defaults to 0)
         K1: first order correction to radial covariant component (defaults to 0)
+        iota1: first order correction to rotational transform (defaults to 0)
         B0z: amplitude of symmetry-breaking perturbation mode
         n: toroidal mode number for the perturbation
         m: poloidal mode bumber for the perturbation

--- a/src/firm3d/field/tracing.py
+++ b/src/firm3d/field/tracing.py
@@ -103,7 +103,8 @@ def trace_particles_boozer_perturbed(
         + |B| q v_{||} (1 + \alpha_{,\psi} I + \alpha I'(\psi))
         + (m v_{||}^2/|B|) (|B| I'(\psi) - |B|_{,\psi} I)\Big)/D
 
-        \dot v_{||} = \Big((|B|q/m) \big(-m \mu (|B|_{,\zeta}(1 + \alpha_{,\psi} I + \alpha I'(\psi))
+        \dot v_{||} = \Big((|B|q/m) \big(-m \mu
+        (|B|_{,\zeta}(1 + \alpha_{,\psi} I + \alpha I'(\psi))
         + |B|_{,\psi} (\alpha_{,\theta} G - \alpha_{,\zeta} I)
         + |B|_{,\theta} (\iota - \alpha G'(\psi) - \alpha_{,\psi} G))
         - q \big(\dot{\alpha} (G + I (\iota - \alpha G'(\psi)) + \alpha G I'(\psi))

--- a/src/firm3d/field/tracing.py
+++ b/src/firm3d/field/tracing.py
@@ -80,31 +80,46 @@ def trace_particles_boozer_perturbed(
     where :math:`q` is the charge, :math:`m` is the mass, and
     :math:`v_\perp^2 = 2\mu|B|`.
 
-    In the case of ``mode='gc'`` we solve the general guiding center equations
-    for an MHD equilibrium:
+    Note that the current implementation has no perturbed guiding-center RHS
+    that retains a general :math:`K(s,\theta,\zeta)`. For perturbed tracing,
+    ``mode='gc'`` and ``mode='gc_noK'`` both evaluate the :math:`K=0`
+    equations below; a full-:math:`K` equilibrium is silently treated as
+    :math:`K=0` whenever a shear Alfvén wave perturbation is present. In the
+    case of ``mode='gc'`` we solve the guiding center equations with
+    :math:`K=0`:
 
     .. math::
 
-        \dot s = (I |B|_{,\zeta} - G |B|_{,\theta})m(v_{||}^2/|B| + \mu)
-        /(\iota D \psi_0)
+        \dot s = \Big(-G \Phi_{,\theta}q + I\Phi_{,\zeta}q
+        + |B| qv_{||}(\alpha_{,\theta}G-\alpha_{,\zeta}I)
+        + (-|B|_{,\theta}G + |B|_{,\zeta}I)
+        (mv_{||}^2/|B| + m\mu)\Big)/(D \psi_0)
 
-        \dot \theta = ((G |B|_{,\psi} - K |B|_{,\zeta}) m(v_{||}^2/|B| + \mu)
-        - C v_{||} |B|)/(\iota D)
+        \dot \theta = \Big(G q \Phi_{,\psi}
+        + |B| q v_{||} (-\alpha_{,\psi} G - \alpha G'(\psi) + \iota)
+        - G'(\psi) m v_{||}^2 + |B|_{,\psi} G (mv_{||}^2/|B| + m\mu)\Big)/D
 
-        \dot \zeta = (F v_{||} |B| - (|B|_{,\psi} I - |B|_{,\theta} K)
-        m(\rho_{||}^2 |B| + \mu) )/(\iota D)
+        \dot \zeta = \Big(-I (|B|_{,\psi} m \mu + \Phi_{,\psi} q)
+        + |B| q v_{||} (1 + \alpha_{,\psi} I + \alpha I'(\psi))
+        + (m v_{||}^2/|B|) (|B| I'(\psi) - |B|_{,\psi} I)\Big)/D
 
-        \dot v_{||} = (C|B|_{,\theta} - F|B|_{,\zeta})\mu |B|/(\iota D)
+        \dot v_{||} = \Big((|B|q/m) \big(-m \mu (|B|_{,\zeta}(1 + \alpha_{,\psi} I + \alpha I'(\psi))
+        + |B|_{,\psi} (\alpha_{,\theta} G - \alpha_{,\zeta} I)
+        + |B|_{,\theta} (\iota - \alpha G'(\psi) - \alpha_{,\psi} G))
+        - q \big(\dot{\alpha} (G + I (\iota - \alpha G'(\psi)) + \alpha G I'(\psi))
+        + (\alpha_{,\theta} G - \alpha_{,\zeta} I) \Phi_{,\psi}
+        + (\iota - \alpha G'(\psi) - \alpha_{,\psi} G) \Phi_{,\theta}
+        + (1 + \alpha I'(\psi) + \alpha_{,\psi} I) \Phi_{,\zeta}\big) \big)
+        + (q v_{||}/|B|) \big((|B|_{,\theta} G - |B|_{,\zeta} I) \Phi_{,\psi}
+        + |B|_{,\psi} (I \Phi_{,\zeta} - G \Phi_{,\theta})\big)
+        + v_{||} \big(m \mu (|B|_{,\theta} G'(\psi) - |B|_{,\zeta} I'(\psi))
+        + q (\dot \alpha (G'(\psi) I - G I'(\psi))
+        + G'(\psi) \Phi_{,\theta} - I'(\psi)\Phi_{,\zeta})\big)\Big)/D
 
-        C = - m v_{||} K_{,\zeta}/|B|  - q \iota + m v_{||}G'/|B|
+        D = q (G + I(-\alpha G'(\psi) + \iota) + \alpha G I'(\psi))
+        + (m v_{||}/|B|) (-G'(\psi)I + G I'(\psi))
 
-        F = - m v_{||} K_{,\theta}/|B| + q + m v_{||}I'/|B|
-
-        D = (F G - C I)/\iota
-
-    where primes indicate differentiation wrt :math:`\psi`. In the case
-    ``mode='gc_noK'``,
-    the above equations are used with :math:`K=0`.
+    where primes indicate differentiation wrt :math:`\psi`.
 
     Args:
         perturbed_field: The :class:`ShearAlfvenWave` instance
@@ -136,10 +151,10 @@ def trace_particles_boozer_perturbed(
         n_zetas: list of toroidal mode numbers for stopping criterion
         m_thetas: list of poloidal mode numbers for stopping criterion
         omegas: list of frequencies defining a stopping criterion such that
-              n_zetas*zetas + m_thetas*thetas - omega_thetas*t = phase. Must have the
-              same length as thetas.
+              n_zetas*zeta + m_thetas*theta - omegas*t = phases. Must have the
+              same length as phases.
               If provided, the solver will stop when the particle hits the
-              plane defined by thetas and omega_thetas.
+              plane defined by n_zetas, m_thetas, and omegas.
         vpars: list of parallel velocities defining a stopping criterion such
               that the solver will stop when the particle hits these values.
         stopping_criteria: list of stopping criteria, mostly used in
@@ -174,15 +189,13 @@ def trace_particles_boozer_perturbed(
 
         - ``res_hits``:
             A list of numpy arrays (one for each particle) containing
-            information on each time the particle hits one of the zeta planes or
+            information on each time the particle hits one of the phase planes or
             one of the stopping criteria. Each row or the array contains
             `[time] + [idx] + state`, where `idx` tells us which of the hit
             planes or stopping criteria was hit.
             If `idx>=0` and `idx<len(phases)`, then the `phases[idx]` plane was
             hit. If `len(vpars)+len(phases)>idx>=len(phases)`, then the
-            `vpars[idx-len(phases)]` plane was hit.
-            If `idx>=len(vpars)+len(phases)`, then the
-            `thetas[idx-len(vpars)-len(phases)]` plane was hit.
+            `vpars[idx-len(phases)]` value was hit.
             If `idx<0`, then `stopping_criteria[int(-idx)-1]` was hit. The
             state vector is `[s, theta, zeta, v_par, t]`.
     """
@@ -369,10 +382,10 @@ def trace_particles_boozer(
         n_zetas: list of toroidal mode numbers for stopping criterion
         m_thetas: list of poloidal mode numbers for stopping criterion
         omegas: list of frequencies defining a stopping criterion such that
-              n_zetas*zetas + m_thetas*thetas - omega_thetas*t = phase. Must have the
-              same length as thetas.
+              n_zetas*zeta + m_thetas*theta - omegas*t = phases. Must have the
+              same length as phases.
               If provided, the solver will stop when the particle hits the
-              plane defined by thetas and omega_thetas.
+              plane defined by n_zetas, m_thetas, and omegas.
         vpars: list of parallel velocities defining a stopping criterion such
               that the solver will stop when the particle hits these values.
         stopping_criteria: list of stopping criteria, mostly used in
@@ -416,15 +429,13 @@ def trace_particles_boozer(
 
         - ``res_hits``:
             A list of numpy arrays (one for each particle) containing
-            information on each time the particle hits one of the zeta planes or
+            information on each time the particle hits one of the phase planes or
             one of the stopping criteria. Each row or the array contains
             `[time] + [idx] + state`, where `idx` tells us which of the hit
             planes or stopping criteria was hit.
-            If `idx>=0` and `idx<len(phases)`, then the `zetas[idx]` plane was hit.
+            If `idx>=0` and `idx<len(phases)`, then the `phases[idx]` plane was hit.
             If `len(vpars)+len(phases)>idx>=len(phases)`, then the
-            `vpars[idx-len(phases)]` plane was hit.
-            If `idx>=len(vpars)+len(phases)`, then the
-            `thetas[idx-len(vpars)-len(phases)]` plane was hit.
+            `vpars[idx-len(phases)]` value was hit.
             If `idx<0`, then `stopping_criteria[int(-idx)-1]` was hit.
             The state vector is `[s, theta, zeta, v_par]`.
     """

--- a/src/firm3d/field/trajectory_helpers.py
+++ b/src/firm3d/field/trajectory_helpers.py
@@ -1906,7 +1906,8 @@ class PassingPerturbedPoincare:
         Return the Poincare map data.
 
         Returns:
-            s_all, chis_all, etas_all, vpars_all, t_all : Lists of trajectory data.
+            s_all, chis_all, etas_all, vpars_all, t_all, DA_all, DA_times :
+                Lists of trajectory data.
         """
         return (
             self.s_all,


### PR DESCRIPTION
Follow-up to #59: audited README.md, all docs/*.rst files, and the BoozerAnalytic/tracing docstrings against the actual implementation, fixing drift and copy-paste errors:

- Replace stale `firm3d.field.trajectory_helpers` import paths (module was split into `firm3d.field.tracing` and `firm3d.trajectory_helpers` on the equilibrium_map branch) throughout docs and api.rst.
- Remove documented ZetaStoppingCriterion/VparStoppingCriterion usage, which are not exposed to Python; use the real vpars/vpars_stop mechanism instead.
- Fix fabricated third "thetas" hit-index category and duplicate leading `t` in the hit state vector, in both docs and tracing.py's own docstrings.
- Fix broken usage examples: BoozerAnalytic (missing psi0, wrong eta_bar, scalar args where lists are required), ShearAlfvenHarmonic (m=/n= -> Phim=/Phin=), ShearAlfvenWavesSuperposition(wave) -> Superposition([wave]), .phi() -> .Phi(), field.B() -> field.modB(), solveSympl -> ODE_solver="symplectic" via solver_options, and PassingPerturbedPoincare.get_poincare_data()'s 5- vs 7-tuple return.
- Fix stale iota(s)=iota_0 formula (code supports iota0 + s*iota1) and field_type "no_k" -> "nok".
- Fix a dimensionally-inconsistent mu term in the guiding-center Lagrangian (needed a factor of m) and document that perturbed tracing's mode='gc' currently behaves like mode='gc_noK', since no K-including perturbed RHS exists in the C++ backend.

Verified against master's copy of the C++/Python implementation (pre-trajectory_helpers-package-split); all referenced APIs, class signatures, and behaviors matched.

## Summary by Sourcery

Improve accuracy and consistency of guiding-center tracing documentation and docstrings, especially for perturbed Boozer integration and stopping/trajectory-saving semantics.

Enhancements:
- Clarify that perturbed guiding-center modes `gc` and `gc_noK` both use K=0 equations and document the full K=0 RHS for Boozer perturbed tracing.
- Correct BoozerAnalytic field and rotational-transform formulas and argument list to reflect the implemented s-linear dependence, including `iota1`.
- Update `PassingPerturbedPoincare.get_poincare_data`’s documented return signature to include DA-related outputs.

Documentation:
- Fix guiding-center Lagrangian definitions, including the magnetic moment and covariant field expressions, and align trajectory state variables with implementation conventions.
- Revise README and reStructuredText docs covering guiding-center modes, shear Alfvén perturbations, stopping criteria, trajectory saving, magnetic-axis handling, and solver options to match the actual APIs and behaviors, including phase-based Poincaré hits and `ODE_solver` configuration.
- Clarify stopping-criterion usage by removing references to non-exposed Zeta/Vpar criteria and documenting the supported `vpars`/`vpars_stop` mechanism.