### PR TITLE
Fix/position init seed comm

### DIFF
--- a/src/firm3d/field/tracing_helpers.py
+++ b/src/firm3d/field/tracing_helpers.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-from .._core.util import parallel_loop_bounds
-
 __all__ = [
     "initialize_position_uniform_surf",
     "initialize_position_profile",
@@ -24,16 +22,19 @@ def initialize_position_uniform_surf(
         ns_max : Number of points in s direction for Jacobian computation
         ntheta_max : Number of points in theta direction for Jacobian computation
         nzeta_max : Number of points in zeta direction for Jacobian computation
-        comm : MPI communicator (default: None)
-        seed: Random seed for reproducibility (default: None, uses random seed
-            from numpy)
+        comm : MPI communicator (default: None). Sampling is performed on rank
+            0 and the result is broadcast, so the returned positions do not
+            depend on the number of ranks.
+        seed: Random seed for reproducibility (default: None, in which case the
+            global numpy RNG is left untouched)
 
     Returns:
         points: A numpy array of shape (nparticles, 3) containing the
             initialized particle positions in Boozer coordinates (s, theta, zeta).
     """
     nfp = field.nfp
-    np.random.seed(seed)
+    if seed is not None:
+        np.random.seed(seed)
     # Compute max value of Jacobian on a grid for normalization
     theta_grid = np.linspace(0, 2 * np.pi, ntheta_max, endpoint=False)
     zeta_grid = np.linspace(0, 2 * np.pi / nfp, nzeta_max, endpoint=False)
@@ -62,46 +63,52 @@ def initialize_position_uniform_surf(
         )
     J_max = np.max(J_vals * sign)
 
-    theta_init = []
-    zeta_init = []
-    s_init = []
-    points = np.zeros((1, 3))
+    # Sample on rank 0 only and broadcast the result.  Every rank seeds the
+    # global numpy RNG identically, so drawing a per-rank slice from that
+    # stream would make all ranks generate the same points.  Sampling on a
+    # single rank also keeps the returned distribution independent of the
+    # number of ranks, so a given seed reproduces the same particles whether
+    # the run is serial or parallel.
+    root = comm.rank == 0 if comm is not None else True
 
-    first, last = parallel_loop_bounds(comm, nparticles)
-    for _i in range(first, last):
-        while True:
-            rand1 = np.random.uniform(0, 1, None)
-            theta = np.random.uniform(0, 2 * np.pi, None)
-            zeta = np.random.uniform(0, 2 * np.pi / nfp, None)
-            points[:, 0] = s
-            points[:, 1] = theta
-            points[:, 2] = zeta
-            field.set_points(points)
-            J = (field.G()[0, 0] + field.iota()[0, 0] * field.I()[0, 0]) / (
-                field.modB()[0, 0] ** 2
-            )
+    stz_init = None
+    if root:
+        theta_init = []
+        zeta_init = []
+        s_init = []
+        points = np.zeros((1, 3))
 
-            # Normalize the Jacobian
-            prob_norm = J * sign / J_max
+        for _i in range(nparticles):
+            while True:
+                rand1 = np.random.uniform(0, 1, None)
+                theta = np.random.uniform(0, 2 * np.pi, None)
+                zeta = np.random.uniform(0, 2 * np.pi / nfp, None)
+                points[:, 0] = s
+                points[:, 1] = theta
+                points[:, 2] = zeta
+                field.set_points(points)
+                J = (field.G()[0, 0] + field.iota()[0, 0] * field.I()[0, 0]) / (
+                    field.modB()[0, 0] ** 2
+                )
 
-            if rand1 <= prob_norm:
-                s_init.append(s)
-                theta_init.append(theta)
-                zeta_init.append(zeta)
-                break
+                # Normalize the Jacobian
+                prob_norm = J * sign / J_max
 
-    # Gather all particle positions across all processes
+                if rand1 <= prob_norm:
+                    s_init.append(s)
+                    theta_init.append(theta)
+                    zeta_init.append(zeta)
+                    break
+
+        stz_init = np.zeros((nparticles, 3))
+        stz_init[:, 0] = np.asarray(s_init)
+        stz_init[:, 1] = np.asarray(theta_init)
+        stz_init[:, 2] = np.asarray(zeta_init)
+
     if comm is not None:
-        s_init = [i for o in comm.allgather(s_init) for i in o]
-        theta_init = [i for o in comm.allgather(theta_init) for i in o]
-        zeta_init = [i for o in comm.allgather(zeta_init) for i in o]
+        stz_init = comm.bcast(stz_init, root=0)
 
-    points = np.zeros((nparticles, 3))
-    points[:, 0] = np.asarray(s_init)
-    points[:, 1] = np.asarray(theta_init)
-    points[:, 2] = np.asarray(zeta_init)
-
-    return points
+    return stz_init
 
 
 def initialize_position_profile(
@@ -142,9 +149,11 @@ def initialize_position_profile(
         ns_max : Number of points in s direction for Jacobian computation
         ntheta_max : Number of points in theta direction for Jacobian computation
         nzeta_max : Number of points in zeta direction for Jacobian computation
-        comm : MPI communicator (default: None)
-        seed: Random seed for reproducibility (default: None, uses random seed
-            from numpy)
+        comm : MPI communicator (default: None). Sampling is performed on rank
+            0 and the result is broadcast, so the returned positions do not
+            depend on the number of ranks.
+        seed: Random seed for reproducibility (default: None, in which case the
+            global numpy RNG is left untouched)
 
     Returns:
         points: A numpy array of shape (nparticles, 3) containing the
@@ -156,7 +165,8 @@ def initialize_position_profile(
             "argument (s) and returns a value."
         )
 
-    np.random.seed(seed)
+    if seed is not None:
+        np.random.seed(seed)
     # Compute max value of Jacobian and p on a grid for normalization
     nfp = field.nfp
     s_grid = np.linspace(0, 1, ns_max)
@@ -195,47 +205,53 @@ def initialize_position_profile(
         J_vals * sign * profile_values
     )  # Normalize by the maximum value of J * profile
 
-    theta_init = []
-    zeta_init = []
-    s_init = []
-    points = np.zeros((1, 3))
+    # Sample on rank 0 only and broadcast the result.  Every rank seeds the
+    # global numpy RNG identically, so drawing a per-rank slice from that
+    # stream would make all ranks generate the same points.  Sampling on a
+    # single rank also keeps the returned distribution independent of the
+    # number of ranks, so a given seed reproduces the same particles whether
+    # the run is serial or parallel.
+    root = comm.rank == 0 if comm is not None else True
 
-    first, last = parallel_loop_bounds(comm, nparticles)
-    for _i in range(first, last):
-        while True:
-            rand1 = np.random.uniform(0, 1, None)
-            s = np.random.uniform(0, 1.0, None)
-            theta = np.random.uniform(0, 2 * np.pi, None)
-            zeta = np.random.uniform(0, 2 * np.pi / nfp, None)
-            points[:, 0] = s
-            points[:, 1] = theta
-            points[:, 2] = zeta
-            field.set_points(points)
-            J = (field.G()[0, 0] + field.iota()[0, 0] * field.I()[0, 0]) / (
-                field.modB()[0, 0] ** 2
-            )
+    stz_init = None
+    if root:
+        theta_init = []
+        zeta_init = []
+        s_init = []
+        points = np.zeros((1, 3))
 
-            # Normalize the probability
-            prob_norm = J * sign * profile(s) / prob_max
+        for _i in range(nparticles):
+            while True:
+                rand1 = np.random.uniform(0, 1, None)
+                s = np.random.uniform(0, 1.0, None)
+                theta = np.random.uniform(0, 2 * np.pi, None)
+                zeta = np.random.uniform(0, 2 * np.pi / nfp, None)
+                points[:, 0] = s
+                points[:, 1] = theta
+                points[:, 2] = zeta
+                field.set_points(points)
+                J = (field.G()[0, 0] + field.iota()[0, 0] * field.I()[0, 0]) / (
+                    field.modB()[0, 0] ** 2
+                )
 
-            if rand1 <= prob_norm:
-                s_init.append(s)
-                theta_init.append(theta)
-                zeta_init.append(zeta)
-                break
+                # Normalize the probability
+                prob_norm = J * sign * profile(s) / prob_max
 
-    # Gather all particle positions across all processes
+                if rand1 <= prob_norm:
+                    s_init.append(s)
+                    theta_init.append(theta)
+                    zeta_init.append(zeta)
+                    break
+
+        stz_init = np.zeros((nparticles, 3))
+        stz_init[:, 0] = np.asarray(s_init)
+        stz_init[:, 1] = np.asarray(theta_init)
+        stz_init[:, 2] = np.asarray(zeta_init)
+
     if comm is not None:
-        s_init = [i for o in comm.allgather(s_init) for i in o]
-        theta_init = [i for o in comm.allgather(theta_init) for i in o]
-        zeta_init = [i for o in comm.allgather(zeta_init) for i in o]
+        stz_init = comm.bcast(stz_init, root=0)
 
-    points = np.zeros((nparticles, 3))
-    points[:, 0] = np.asarray(s_init)
-    points[:, 1] = np.asarray(theta_init)
-    points[:, 2] = np.asarray(zeta_init)
-
-    return points
+    return stz_init
 
 
 def initialize_position_uniform_vol(
@@ -257,9 +273,11 @@ def initialize_position_uniform_vol(
         ns_max : Number of points in s direction for Jacobian computation
         ntheta_max : Number of points in theta direction for Jacobian computation
         nzeta_max : Number of points in zeta direction for Jacobian computation
-        comm : MPI communicator (default: None)
-        seed: Random seed for reproducibility (default: None, uses random seed
-            from numpy)
+        comm : MPI communicator (default: None). Sampling is performed on rank
+            0 and the result is broadcast, so the returned positions do not
+            depend on the number of ranks.
+        seed: Random seed for reproducibility (default: None, in which case the
+            global numpy RNG is left untouched)
 
     Returns:
         points: A numpy array of shape (nparticles, 3) containing the

--- a/src/firm3d/field/tracing_helpers.py
+++ b/src/firm3d/field/tracing_helpers.py
@@ -63,12 +63,7 @@ def initialize_position_uniform_surf(
         )
     J_max = np.max(J_vals * sign)
 
-    # Sample on rank 0 only and broadcast the result.  Every rank seeds the
-    # global numpy RNG identically, so drawing a per-rank slice from that
-    # stream would make all ranks generate the same points.  Sampling on a
-    # single rank also keeps the returned distribution independent of the
-    # number of ranks, so a given seed reproduces the same particles whether
-    # the run is serial or parallel.
+    # Sample on rank 0 only and broadcast the result.
     root = comm.rank == 0 if comm is not None else True
 
     stz_init = None
@@ -205,12 +200,7 @@ def initialize_position_profile(
         J_vals * sign * profile_values
     )  # Normalize by the maximum value of J * profile
 
-    # Sample on rank 0 only and broadcast the result.  Every rank seeds the
-    # global numpy RNG identically, so drawing a per-rank slice from that
-    # stream would make all ranks generate the same points.  Sampling on a
-    # single rank also keeps the returned distribution independent of the
-    # number of ranks, so a given seed reproduces the same particles whether
-    # the run is serial or parallel.
+    # Sample on rank 0 only and broadcast the result.
     root = comm.rank == 0 if comm is not None else True
 
     stz_init = None

--- a/tests/field/test_tracing_helpers.py
+++ b/tests/field/test_tracing_helpers.py
@@ -1,0 +1,158 @@
+"""
+Tests for the position/velocity initialization helpers in tracing_helpers.
+
+Verifies that:
+- A given seed reproduces the same sample, and different seeds do not
+- seed=None leaves the caller's global numpy RNG state alone
+- Sampled positions lie in the expected domain
+- Under MPI, every rank receives the identical sample, the sample contains
+  no duplicated particles, and the sample does not depend on the number of
+  ranks
+
+The MPI assertions are the regression guard for the case where positions were
+sampled from a per-rank slice of a commonly seeded RNG: every rank generated
+the same points, so the gathered array held only nparticles/comm.size unique
+positions, each repeated comm.size times. That failure is silent -- the array
+shape is correct and tracing runs normally -- so it is asserted on explicitly
+here rather than being left to surface as noisy statistics downstream.
+
+Note that test_sample_independent_of_comm_size and
+test_no_duplicate_particles_under_mpi only have force when the suite is run
+under more than one rank (e.g. mpirun -n 2 python -m pytest ...); they skip
+otherwise, since the bug they cover cannot occur in a single process.
+"""
+
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+from firm3d.field.boozermagneticfield import (
+    BoozerRadialInterpolant,
+    InterpolatedBoozerField,
+)
+from firm3d.field.tracing_helpers import (
+    initialize_position_profile,
+    initialize_position_uniform_surf,
+    initialize_position_uniform_vol,
+)
+
+try:
+    from mpi4py import MPI
+
+    comm = MPI.COMM_WORLD
+except ImportError:
+    comm = None
+
+TEST_DIR = (Path(__file__).parent / ".." / "test_files").resolve()
+TEST_FILE = str((TEST_DIR / "boozmn_LandremanPaul2021_QA_lowres.nc").resolve())
+
+# Small grids everywhere: these tests exercise the sampling/communication
+# structure, not interpolation accuracy.
+NPARTICLES = 64
+GRID = {"ns_max": 10, "ntheta_max": 10, "nzeta_max": 10}
+
+
+def reactivity(s):
+    return (1 - s**5) ** 2
+
+
+class TracingHelpersTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not Path(TEST_FILE).exists():
+            raise unittest.SkipTest(f"Test file not found: {TEST_FILE}")
+        bri = BoozerRadialInterpolant(TEST_FILE, 3, comm=comm)
+        cls.field = InterpolatedBoozerField(
+            bri, degree=3, ns_interp=24, ntheta_interp=24, nzeta_interp=24
+        )
+
+    def _sample(self, seed, nparticles=NPARTICLES):
+        return initialize_position_profile(
+            self.field, nparticles, reactivity, comm=comm, seed=seed, **GRID
+        )
+
+    def test_seed_is_reproducible(self):
+        np.testing.assert_array_equal(self._sample(0), self._sample(0))
+
+    def test_different_seeds_differ(self):
+        self.assertFalse(np.array_equal(self._sample(0), self._sample(1)))
+
+    def test_none_seed_preserves_rng_state(self):
+        """
+        seed=None must not reseed the global RNG: a caller that seeded numpy
+        itself should still get its own reproducible stream afterwards.
+        """
+        np.random.seed(12345)
+        self._sample(None)
+        after_first = np.random.uniform(0, 1, 5)
+
+        np.random.seed(12345)
+        self._sample(None)
+        after_second = np.random.uniform(0, 1, 5)
+
+        np.testing.assert_array_equal(after_first, after_second)
+
+    def test_positions_in_domain(self):
+        points = self._sample(0)
+        self.assertEqual(points.shape, (NPARTICLES, 3))
+        self.assertTrue(np.all((points[:, 0] >= 0) & (points[:, 0] <= 1)))
+        self.assertTrue(np.all((points[:, 1] >= 0) & (points[:, 1] <= 2 * np.pi)))
+        nfp = self.field.nfp
+        self.assertTrue(np.all((points[:, 2] >= 0) & (points[:, 2] <= 2 * np.pi / nfp)))
+
+    def test_uniform_surf_stays_on_surface(self):
+        s = 0.3
+        points = initialize_position_uniform_surf(
+            self.field, NPARTICLES, s, ntheta_max=10, nzeta_max=10, comm=comm, seed=0
+        )
+        np.testing.assert_allclose(points[:, 0], s)
+
+    def test_uniform_vol_matches_flat_profile(self):
+        vol = initialize_position_uniform_vol(
+            self.field, NPARTICLES, comm=comm, seed=0, **GRID
+        )
+        flat = initialize_position_profile(
+            self.field, NPARTICLES, lambda s: 1.0, comm=comm, seed=0, **GRID
+        )
+        np.testing.assert_array_equal(vol, flat)
+
+    @unittest.skipIf(comm is None, "mpi4py not available")
+    def test_all_ranks_receive_same_sample(self):
+        points = self._sample(0)
+        gathered = comm.allgather(points)
+        for other in gathered[1:]:
+            np.testing.assert_array_equal(gathered[0], other)
+
+    @unittest.skipIf(comm is None or comm.size == 1, "requires >1 MPI rank")
+    def test_no_duplicate_particles_under_mpi(self):
+        """
+        Regression guard: sampling a per-rank slice from a commonly seeded RNG
+        yielded only nparticles/comm.size unique positions.
+        """
+        for seed in (0, 42):
+            points = self._sample(seed)
+            unique = np.unique(points, axis=0)
+            self.assertEqual(
+                len(unique),
+                NPARTICLES,
+                f"seed={seed}: {len(unique)}/{NPARTICLES} unique positions on "
+                f"{comm.size} ranks -- sample is degenerate",
+            )
+
+    @unittest.skipIf(comm is None or comm.size == 1, "requires >1 MPI rank")
+    def test_sample_independent_of_comm_size(self):
+        """
+        A seeded sample must not depend on how many ranks the run uses. The
+        serial result is recomputed here with comm=None on every rank and
+        compared against the parallel result.
+        """
+        parallel = self._sample(0)
+        serial = initialize_position_profile(
+            self.field, NPARTICLES, reactivity, comm=None, seed=0, **GRID
+        )
+        np.testing.assert_array_equal(parallel, serial)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/field/test_tracing_helpers.py
+++ b/tests/field/test_tracing_helpers.py
@@ -77,10 +77,10 @@ class TracingHelpersTests(unittest.TestCase):
     @unittest.skipIf(comm is None, "mpi4py not available")
     def test_all_ranks_get_the_same_distinct_sample(self):
         """
-        The sample is drawn once on rank 0 and broadcast. Previously each rank
-        sampled its own slice of the particles from an identically seeded RNG,
-        so the gathered array repeated the same nparticles/comm.size positions
-        -- silently, since the shape was still correct.
+        The sample is drawn once on rank 0 and broadcast, so every rank must
+        hold the same array of nparticles distinct positions. A sample that
+        repeats positions across ranks still has the expected shape, so the
+        distinctness is asserted on directly.
         """
         for sample in SAMPLERS:
             with self.subTest(sample.__name__):

--- a/tests/field/test_tracing_helpers.py
+++ b/tests/field/test_tracing_helpers.py
@@ -1,40 +1,19 @@
 """
-Tests for the position/velocity initialization helpers in tracing_helpers.
-
-Verifies that:
-- A given seed reproduces the same sample, and different seeds do not
-- seed=None leaves the caller's global numpy RNG state alone
-- Sampled positions lie in the expected domain
-- Under MPI, every rank receives the identical sample, the sample contains
-  no duplicated particles, and the sample does not depend on the number of
-  ranks
-
-The MPI assertions are the regression guard for the case where positions were
-sampled from a per-rank slice of a commonly seeded RNG: every rank generated
-the same points, so the gathered array held only nparticles/comm.size unique
-positions, each repeated comm.size times. That failure is silent -- the array
-shape is correct and tracing runs normally -- so it is asserted on explicitly
-here rather than being left to surface as noisy statistics downstream.
-
-Note that test_sample_independent_of_comm_size and
-test_no_duplicate_particles_under_mpi only have force when the suite is run
-under more than one rank (e.g. mpirun -n 2 python -m pytest ...); they skip
-otherwise, since the bug they cover cannot occur in a single process.
+Tests for the position initialization helpers in tracing_helpers, covering the
+two behaviors changed by the seed/comm fix: seed=None must leave the caller's
+global numpy RNG alone, and a seeded sample must be identical on every rank.
+The rank assertions only have force under more than one rank, e.g.
+mpirun -n 2 python -m pytest tests/field/test_tracing_helpers.py
 """
 
 import unittest
-from pathlib import Path
 
 import numpy as np
 
-from firm3d.field.boozermagneticfield import (
-    BoozerRadialInterpolant,
-    InterpolatedBoozerField,
-)
+from firm3d.field.boozermagneticfield import BoozerAnalytic
 from firm3d.field.tracing_helpers import (
     initialize_position_profile,
     initialize_position_uniform_surf,
-    initialize_position_uniform_vol,
 )
 
 try:
@@ -44,114 +23,71 @@ try:
 except ImportError:
     comm = None
 
-TEST_DIR = (Path(__file__).parent / ".." / "test_files").resolve()
-TEST_FILE = str((TEST_DIR / "boozmn_LandremanPaul2021_QA_lowres.nc").resolve())
+NPARTICLES = 32
 
-# Small grids everywhere: these tests exercise the sampling/communication
-# structure, not interpolation accuracy.
-NPARTICLES = 64
-GRID = {"ns_max": 10, "ntheta_max": 10, "nzeta_max": 10}
+# An analytic field keeps these tests about the sampling and communication
+# structure: no equilibrium file to read and no interpolant to build.
+FIELD = BoozerAnalytic(etabar=1.2, B0=1.0, N=0, G0=1.1, psi0=1.0, iota0=0.4)
 
 
-def reactivity(s):
-    return (1 - s**5) ** 2
+def sample_profile(seed):
+    return initialize_position_profile(
+        FIELD,
+        NPARTICLES,
+        lambda s: (1 - s**5) ** 2,
+        ns_max=5,
+        ntheta_max=5,
+        nzeta_max=5,
+        comm=comm,
+        seed=seed,
+    )
+
+
+def sample_surf(seed):
+    return initialize_position_uniform_surf(
+        FIELD, NPARTICLES, 0.3, ntheta_max=5, nzeta_max=5, comm=comm, seed=seed
+    )
+
+
+# initialize_position_uniform_vol delegates to initialize_position_profile, so
+# these two cover both copies of the sampling loop.
+SAMPLERS = (sample_profile, sample_surf)
 
 
 class TracingHelpersTests(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        if not Path(TEST_FILE).exists():
-            raise unittest.SkipTest(f"Test file not found: {TEST_FILE}")
-        bri = BoozerRadialInterpolant(TEST_FILE, 3, comm=comm)
-        cls.field = InterpolatedBoozerField(
-            bri, degree=3, ns_interp=24, ntheta_interp=24, nzeta_interp=24
-        )
-
-    def _sample(self, seed, nparticles=NPARTICLES):
-        return initialize_position_profile(
-            self.field, nparticles, reactivity, comm=comm, seed=seed, **GRID
-        )
-
     def test_seed_is_reproducible(self):
-        np.testing.assert_array_equal(self._sample(0), self._sample(0))
-
-    def test_different_seeds_differ(self):
-        self.assertFalse(np.array_equal(self._sample(0), self._sample(1)))
+        for sample in SAMPLERS:
+            with self.subTest(sample.__name__):
+                points = sample(0)
+                self.assertEqual(points.shape, (NPARTICLES, 3))
+                np.testing.assert_array_equal(points, sample(0))
 
     def test_none_seed_preserves_rng_state(self):
-        """
-        seed=None must not reseed the global RNG: a caller that seeded numpy
-        itself should still get its own reproducible stream afterwards.
-        """
-        np.random.seed(12345)
-        self._sample(None)
-        after_first = np.random.uniform(0, 1, 5)
+        """seed=None must not reseed the caller's global numpy RNG."""
+        for sample in SAMPLERS:
+            with self.subTest(sample.__name__):
+                np.random.seed(12345)
+                sample(None)
+                expected = np.random.uniform(0, 1, 5)
 
-        np.random.seed(12345)
-        self._sample(None)
-        after_second = np.random.uniform(0, 1, 5)
-
-        np.testing.assert_array_equal(after_first, after_second)
-
-    def test_positions_in_domain(self):
-        points = self._sample(0)
-        self.assertEqual(points.shape, (NPARTICLES, 3))
-        self.assertTrue(np.all((points[:, 0] >= 0) & (points[:, 0] <= 1)))
-        self.assertTrue(np.all((points[:, 1] >= 0) & (points[:, 1] <= 2 * np.pi)))
-        nfp = self.field.nfp
-        self.assertTrue(np.all((points[:, 2] >= 0) & (points[:, 2] <= 2 * np.pi / nfp)))
-
-    def test_uniform_surf_stays_on_surface(self):
-        s = 0.3
-        points = initialize_position_uniform_surf(
-            self.field, NPARTICLES, s, ntheta_max=10, nzeta_max=10, comm=comm, seed=0
-        )
-        np.testing.assert_allclose(points[:, 0], s)
-
-    def test_uniform_vol_matches_flat_profile(self):
-        vol = initialize_position_uniform_vol(
-            self.field, NPARTICLES, comm=comm, seed=0, **GRID
-        )
-        flat = initialize_position_profile(
-            self.field, NPARTICLES, lambda s: 1.0, comm=comm, seed=0, **GRID
-        )
-        np.testing.assert_array_equal(vol, flat)
+                np.random.seed(12345)
+                sample(None)
+                np.testing.assert_array_equal(expected, np.random.uniform(0, 1, 5))
 
     @unittest.skipIf(comm is None, "mpi4py not available")
-    def test_all_ranks_receive_same_sample(self):
-        points = self._sample(0)
-        gathered = comm.allgather(points)
-        for other in gathered[1:]:
-            np.testing.assert_array_equal(gathered[0], other)
-
-    @unittest.skipIf(comm is None or comm.size == 1, "requires >1 MPI rank")
-    def test_no_duplicate_particles_under_mpi(self):
+    def test_all_ranks_get_the_same_distinct_sample(self):
         """
-        Regression guard: sampling a per-rank slice from a commonly seeded RNG
-        yielded only nparticles/comm.size unique positions.
+        The sample is drawn once on rank 0 and broadcast. Previously each rank
+        sampled its own slice of the particles from an identically seeded RNG,
+        so the gathered array repeated the same nparticles/comm.size positions
+        -- silently, since the shape was still correct.
         """
-        for seed in (0, 42):
-            points = self._sample(seed)
-            unique = np.unique(points, axis=0)
-            self.assertEqual(
-                len(unique),
-                NPARTICLES,
-                f"seed={seed}: {len(unique)}/{NPARTICLES} unique positions on "
-                f"{comm.size} ranks -- sample is degenerate",
-            )
-
-    @unittest.skipIf(comm is None or comm.size == 1, "requires >1 MPI rank")
-    def test_sample_independent_of_comm_size(self):
-        """
-        A seeded sample must not depend on how many ranks the run uses. The
-        serial result is recomputed here with comm=None on every rank and
-        compared against the parallel result.
-        """
-        parallel = self._sample(0)
-        serial = initialize_position_profile(
-            self.field, NPARTICLES, reactivity, comm=None, seed=0, **GRID
-        )
-        np.testing.assert_array_equal(parallel, serial)
+        for sample in SAMPLERS:
+            with self.subTest(sample.__name__):
+                points = sample(0)
+                self.assertEqual(len(np.unique(points, axis=0)), NPARTICLES)
+                for other in comm.allgather(points):
+                    np.testing.assert_array_equal(points, other)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary by Sourcery

Ensure MPI-independent, reproducible particle position initialization and add regression tests for RNG seeding and communication.

Bug Fixes:
- Fix particle position sampling so that, under MPI, all ranks receive the same set of positions independent of the number of ranks and without duplicated particles.
- Guard against unintended reseeding of the global numpy RNG when seed=None by only seeding when a seed is explicitly provided.

Enhancements:
- Document MPI behavior and RNG seeding semantics in the position initialization helpers.

Tests:
- Add unit tests verifying RNG reproducibility, domain correctness, MPI consistency, absence of duplicate particles, and independence of samples from the communicator size for tracing helper initializers.