### PR TITLE
Ep gpu tmax guard

### DIFF
--- a/src/firm3dpp/cuda_kernel.cu
+++ b/src/firm3dpp/cuda_kernel.cu
@@ -815,13 +815,6 @@ __device__ void check_has_left<CoordSys::Boozer>(bool* has_left, double* state, 
 // and adjust the step size
 template<RHS id>
 __device__ void adjust_time(double* t, double* dt, double* state, double* derivs, double* x_temp, bool* has_left, double* dtmax){
-    // A block keeps looping while *any* of its particles is still running, so
-    // a particle that is already done still enters here on every remaining
-    // iteration.  Without the tmax test below it would keep integrating --
-    // and, since the dt clamp further down is itself guarded on t < tmax, it
-    // would do so at a frozen step size -- until the slowest particle in the
-    // block finished, reporting its state at that later time instead of at
-    // tmax.  The loop condition tests the same two flags; this mirrors it.
     if(has_left[threadIdx.x] || t[threadIdx.x] >= tmax_d){
         return;
     }

--- a/src/firm3dpp/cuda_kernel.cu
+++ b/src/firm3dpp/cuda_kernel.cu
@@ -815,7 +815,14 @@ __device__ void check_has_left<CoordSys::Boozer>(bool* has_left, double* state, 
 // and adjust the step size
 template<RHS id>
 __device__ void adjust_time(double* t, double* dt, double* state, double* derivs, double* x_temp, bool* has_left, double* dtmax){
-    if(has_left[threadIdx.x]){
+    // A block keeps looping while *any* of its particles is still running, so
+    // a particle that is already done still enters here on every remaining
+    // iteration.  Without the tmax test below it would keep integrating --
+    // and, since the dt clamp further down is itself guarded on t < tmax, it
+    // would do so at a frozen step size -- until the slowest particle in the
+    // block finished, reporting its state at that later time instead of at
+    // tmax.  The loop condition tests the same two flags; this mirrors it.
+    if(has_left[threadIdx.x] || t[threadIdx.x] >= tmax_d){
         return;
     }
     const double bhat1 = 71.0 / 57600.0, bhat3 = -71.0 / 16695.0, bhat4 = 71.0 / 1920.0, bhat5 = -17253.0 / 339200.0, bhat6 = 22.0 / 525.0, bhat7 = -1.0 / 40.0;


### PR DESCRIPTION
## Summary by Sourcery

Ensure GPU particle tracing stops exactly at the configured maximum time per particle and is independent of batch size.

Bug Fixes:
- Prevent GPU tracer particles from continuing to integrate past tmax when other particles in the same CUDA block are still running.

Enhancements:
- Tidy CUDA kernel source formatting and whitespace without changing behavior.

Tests:
- Add a regression test that traces particles in Boozer coordinates across multiple batch sizes to confirm all stop at tmax and produce batch-size-independent results.