### PR TITLE
Clamp angular cell indices from below in RegularGridInterpolant3D

### DIFF
--- a/src/firm3dpp/regular_grid_interpolant_3d_impl.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d_impl.h
@@ -202,17 +202,10 @@ void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double y, doubl
         if(zidx < 0 || zidx >= nz)
             throw std::runtime_error((boost::format("zidxs={} not within [0, {}]") % zidx % (nz-1)).str());
     } else {
-        // Clamp cell indices to match CUDA kernel convention (cuda_kernel.cu:700-704):
-        //   x (s, radial): clamp both lower and upper bounds — s can legitimately
-        //     fall below 0 or above 1 during tracing.
-        //   y (theta), z (zeta): clamp upper bound only — these are periodic
-        //     coordinates and a negative index never occurs in practice.
-        // The coordinate itself is left at its true value so that xlocal can
-        // exceed [0,1), giving polynomial extrapolation from the boundary cell
-        // rather than returning zero (which caused modB=0 and an unbounded RHS).
+        // Clamp cell indices to match CUDA kernel convention (cuda_kernel.cu:700-704).
         xidx = std::max(0, std::min(nx-1, xidx));
-        yidx = std::min(ny-1, yidx);
-        zidx = std::min(nz-1, zidx);
+        yidx = std::max(0, std::min(ny-1, yidx));
+        zidx = std::max(0, std::min(nz-1, zidx));
     }
     double xlocal = (x-xmesh[xidx])/hx;
     double ylocal = (y-ymesh[yidx])/hy;


### PR DESCRIPTION
evaluate_inplace clamped yidx and zidx only from above when out_of_bounds_ok is set, on the assumption that theta and zeta are periodic and so never produce a negative index. The symmetry reduction that callers apply does not establish that: exploit_symmetries_points reduces theta to [0,2*pi] (or [0,pi] under stellarator symmetry) and zeta to [0,2*pi/nfp], which are the periodic domains, not the interpolant's grid range [thetamin,thetamax]. Those coincide only when thetamin and zetamin are zero, and InterpolatedBoozerField accepts any thetarange within [0,2*pi] without warning.

With a restricted angular range an ordinary reduced angle below the grid minimum by more than one cell gives a negative index, which reads ymesh/zmesh before the start of the vector and then evaluates in whatever cell idx_cell maps to. It usually returns a plausible number rather than crashing. On a field built with thetarange = [pi/4, 3pi/4] (the range used by test_interpolatedboozerfield_convergence_rate), modB at theta = 0.3 came back 13% high with no error or warning.

Clamp all three indices from below as well as above. The GPU applies max(...,0) only to the radial index because map_to_grid guarantees the angular ones are already non-negative, so this is a no-op wherever that precondition holds and the two backends still agree on every physical input.

## Summary by Sourcery

Bug Fixes:
- Prevent negative angular cell indices from accessing memory before the start of the theta/zeta grids by clamping y and z indices from below as well as above.