### PR TITLE
Flatten interpolant storage to cut per-rank field memory

### DIFF
--- a/src/firm3dpp/regular_grid_interpolant_3d.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d.h
@@ -1,8 +1,7 @@
 #pragma once
 
 #include "simdhelpers.h"
-#include <unordered_map>
-#include <map>  
+#include <map>
 #include <algorithm>
 #include <functional>
 #include <iostream>
@@ -102,12 +101,22 @@ class RegularGridInterpolant3D {
         // location of the mesh nodes in [xmin, xmax], [ymin, ymax], and [zmin, zmax]. superset of xmesh, ymesh, zmesh
         // has size nx*degree + 1, ny*degree + 1, and nz*degree + 1 respectively
         Vec xdof, ydof, zdof;
-        // subset of the tensor product of the dof locations. if none of the dofs are skipped, these all have size
-        // (nx*degree + 1) * (ny*degree + 1) * (nz*degree + 1), but now they have size dofs_to_keep
-        Vec xdoftensor_reduced, ydoftensor_reduced, zdoftensor_reduced;
 
-        Vec vals; // contains the values of the function to be interpolated at the dofs, of size dofs_to_keep * value_size
-        std::unordered_map<int, AlignedPaddedVec> all_local_vals_map; // maps each cell to an array of size (degree+1)**3 * padded_value_size
+        // values of the function to be interpolated at the dofs, of size
+        // dofs_to_keep * value_size. This array is transient: it is filled
+        // during interpolate_batch()/set_interpolant_data() and freed again
+        // once the per-cell storage below has been built from it.
+        // get_interpolant_data() reconstructs it on demand.
+        Vec vals;
+        // Per-cell storage used for evaluation. For each kept cell,
+        // local_vals_flat holds a contiguous block of
+        // (degree+1)^3 * value_size values (one entry per dof of the cell,
+        // dofs ordered by idx_dof_local, values contiguous per dof). Block
+        // lengths are rounded up to a multiple of the simd width so every
+        // block starts aligned. cell_offsets maps a cell index to the offset
+        // of its block within local_vals_flat, or -1 for skipped cells.
+        AlignedPaddedVec local_vals_flat;
+        std::vector<int64_t> cell_offsets;
         std::vector<bool> skip_cell; // whether to skip each cell or not
         // since we are skipping some dofs, we need mappings into the list of
         // reduced dofs, e.g. if we skip dofs 3, then reduced to full would
@@ -115,28 +124,36 @@ class RegularGridInterpolant3D {
         std::vector<uint32_t> reduced_to_full_map, full_to_reduced_map;
 
         uint32_t cells_to_skip, cells_to_keep, dofs_to_skip, dofs_to_keep; // which cells and dofs we skip and keep
-        int local_vals_size;
-        Vec pkxs, pkys, pkzs;
+        int local_vals_size; // length of each cell's block in local_vals_flat
 
         static const int simdcount = xsimd::simd_type<double>::size; // vector width for simd instructions
-        int padded_value_size; // smallest multiple of simdcount that is larger than value_size
+        static const int MAX_NODES = 16; // upper bound on degree+1, so basis function values fit in stack buffers
 
-        inline int idx_dof(int i, int j, int k){
+        inline int idx_dof(int i, int j, int k) const {
             int degree = rule.degree;
             return i*(ny*degree+1)*(nz*degree+1) + j*(nz*degree+1) + k;
         }
 
-        inline int idx_cell(int i, int j, int k){
+        inline int idx_cell(int i, int j, int k) const {
             return i*ny*nz + j*nz + k;
         }
 
-        inline int idx_mesh(int i, int j, int k){
+        inline int idx_mesh(int i, int j, int k) const {
             return i*(ny+1)*(nz+1) + j*(nz+1) + k;
         }
 
-        inline int idx_dof_local(int i, int j, int k){
+        inline int idx_dof_local(int i, int j, int k) const {
             int degree = rule.degree;
             return i*(degree+1)*(degree+1) + j*(degree+1) + k;
+        }
+
+        // Offset of cell_idx's block in local_vals_flat, or -1 if that cell is
+        // skipped or the index is out of range. Callers may pass an index
+        // outside [0, nx*ny*nz) - see the clamping in evaluate_inplace().
+        inline int64_t cell_lookup(int cell_idx) const {
+            if(cell_idx < 0 || (size_t)cell_idx >= cell_offsets.size())
+                return -1;
+            return cell_offsets[cell_idx];
         }
 
         int locate_unsafe(double x, double y, double z);
@@ -144,6 +161,25 @@ class RegularGridInterpolant3D {
         void evaluate_inplace(double x, double *res);
         void evaluate_local(double x, double y, double z, int cell_idx, double *res);
         void evaluate_local(double x, int cell_idx, double *res);
+        void build_local_vals(); // build local_vals_flat/cell_offsets from vals, then free vals
+        Vec reconstruct_vals() const; // rebuild the dof-ordered vals array from local_vals_flat
+
+        // Fill xsub/ysub/zsub (each of size last-first) with the coordinates
+        // of the reduced dofs [first, last). Computed on the fly from the 1d
+        // dof arrays rather than stored: the full tensor-product coordinate
+        // arrays would triple the interpolant's persistent memory footprint.
+        void dof_coords(uint32_t first, uint32_t last, Vec& xsub, Vec& ysub, Vec& zsub) const {
+            int degree = rule.degree;
+            int nyd = ny*degree+1, nzd = nz*degree+1;
+            for (uint32_t idx = first; idx < last; ++idx) {
+                uint32_t full = reduced_to_full_map[idx];
+                uint32_t i = full / (nyd*nzd);
+                uint32_t rem = full % (nyd*nzd);
+                xsub[idx-first] = xdof[i];
+                ysub[idx-first] = ydof[rem / nzd];
+                zsub[idx-first] = zdof[rem % nzd];
+            }
+        }
 
     public:
 
@@ -155,9 +191,8 @@ class RegularGridInterpolant3D {
             value_size(value_size), out_of_bounds_ok(out_of_bounds_ok)
         {
             int degree = rule.degree;
-            pkxs = Vec(degree+1, 0.);
-            pkys = Vec(degree+1, 0.);
-            pkzs = Vec(degree+1, 0.);
+            if(degree + 1 > MAX_NODES)
+                throw std::invalid_argument("Interpolation degree too large: at most degree 15 is supported");
             hx = (xmax-xmin)/nx;
             hy = (ymax-ymin)/ny;
             hz = (zmax-zmin)/nz;
@@ -228,20 +263,6 @@ class RegularGridInterpolant3D {
                 }
             }
             uint32_t n =  (nx*degree+1)*(ny*degree+1)*(nz*degree+1);
-            // turn these into a tensor product grid
-            Vec xdoftensor(n, 0.);
-            Vec ydoftensor(n, 0.);
-            Vec zdoftensor(n, 0.);
-            for (int i = 0; i <= nx*degree; ++i) {
-                for (int j = 0; j <= ny*degree; ++j) {
-                    for (int k = 0; k <= nz*degree; ++k) {
-                        uint32_t offset = idx_dof(i, j, k);
-                        xdoftensor[offset] = xdof[i];
-                        ydoftensor[offset] = ydof[j];
-                        zdoftensor[offset] = zdof[k];
-                    }
-                }
-            }
             // We need to figure out which of these dofs we keep, and which
             // to discard.  To do this, we loop over the cells, and for each
             // cell that shouldn't be skipped, we mark all dofs in that cell.
@@ -282,21 +303,12 @@ class RegularGridInterpolant3D {
                 }
             }
 
-            // build the reduced list of interpolation points
-            xdoftensor_reduced = Vec(dofs_to_keep, 0.);
-            ydoftensor_reduced = Vec(dofs_to_keep, 0.);
-            zdoftensor_reduced = Vec(dofs_to_keep, 0.);
-            for (long i = 0; i < dofs_to_keep; ++i) {
-                xdoftensor_reduced[i] = xdoftensor[reduced_to_full_map[i]];
-                ydoftensor_reduced[i] = ydoftensor[reduced_to_full_map[i]];
-                zdoftensor_reduced[i] = zdoftensor[reduced_to_full_map[i]];
-            }
-            vals = Vec(dofs_to_keep * value_size, 0.);
-
-            // round up value_size to nearest multiple of simdcount
-            padded_value_size = (value_size + simdcount) - (value_size % simdcount);
-            int nnodes = (nx*degree+1)*(ny*degree+1)*(nz*degree+1);
-            local_vals_size = (degree+1)*(degree+1)*(degree+1)*padded_value_size;
+            // each cell's block holds (degree+1)^3 dofs with value_size values
+            // per dof; round the block length up to a multiple of the simd
+            // width so that every block in local_vals_flat starts aligned
+            int block = (degree+1)*(degree+1)*(degree+1)*value_size;
+            local_vals_size = ((block + simdcount - 1) / simdcount) * simdcount;
+            cell_offsets.assign((size_t)nx*ny*nz, -1);
         }
         RegularGridInterpolant3D(InterpolationRule rule, RangeTriplet xrange, RangeTriplet yrange, RangeTriplet zrange, int value_size, bool out_of_bounds_ok) :
             RegularGridInterpolant3D(rule, xrange, yrange, zrange, value_size, out_of_bounds_ok, [](Vec x, Vec y, Vec z){ return std::vector<bool>(x.size(), false); })
@@ -312,11 +324,12 @@ class RegularGridInterpolant3D {
         void evaluate_batch_1D(Array &xyz, Array &fxyz);
 
         std::pair<double, double> estimate_error(std::function<Vec(Vec, Vec, Vec)> &f, int samples);
-        
+
         // Serialization for InterpolatedBoozerField save/load.
         // get_interpolant_data(): exports vals array and grid params for JSON.
-        // set_interpolant_data(): restores vals and rebuilds all_local_vals_map
-        //                         (the cell-indexed lookup table for evaluation).
+        // set_interpolant_data(): restores vals and rebuilds the per-cell
+        //                         storage (local_vals_flat/cell_offsets) used
+        //                         for evaluation.
         std::map<std::string, std::vector<double>> get_interpolant_data() const;
         void set_interpolant_data(const std::map<std::string, std::vector<double>>& data);
 };

--- a/src/firm3dpp/regular_grid_interpolant_3d.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d.h
@@ -102,20 +102,15 @@ class RegularGridInterpolant3D {
         // has size nx*degree + 1, ny*degree + 1, and nz*degree + 1 respectively
         Vec xdof, ydof, zdof;
 
-        // values of the function to be interpolated at the dofs, of size
-        // dofs_to_keep * value_size. This array is transient: it is filled
-        // during interpolate_batch()/set_interpolant_data() and freed again
-        // once the per-cell storage below has been built from it.
-        // get_interpolant_data() reconstructs it on demand.
+        // dof-ordered function values, of size dofs_to_keep * value_size.
+        // Transient: freed once the per-cell storage below is built from it,
+        // rebuilt on demand by get_interpolant_data().
         Vec vals;
-        // Per-cell storage used for evaluation. For each kept cell,
-        // local_vals_flat holds a contiguous block of
-        // (degree+1)^3 * value_size values (one entry per dof of the cell,
-        // dofs ordered by idx_dof_local, values contiguous per dof).
-        // cell_offsets maps a cell index to the offset of its block within
-        // local_vals_flat, or -1 for skipped cells. It is sized nx*ny*nz from
-        // construction, and evaluate_inplace() clamps or rejects out-of-range
-        // cell indices, so lookups index it directly.
+        // Evaluation storage: one contiguous block of (degree+1)^3 * value_size
+        // values per kept cell (dofs in idx_dof_local order, values contiguous
+        // per dof). cell_offsets[cell] is the block's offset, or -1 for skipped
+        // cells; it is sized nx*ny*nz from construction and evaluate_inplace()
+        // keeps cell indices in range, so lookups index it directly.
         Vec local_vals_flat;
         std::vector<int64_t> cell_offsets;
         std::vector<bool> skip_cell; // whether to skip each cell or not

--- a/src/firm3dpp/regular_grid_interpolant_3d.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d.h
@@ -114,7 +114,9 @@ class RegularGridInterpolant3D {
         // dofs ordered by idx_dof_local, values contiguous per dof). Block
         // lengths are rounded up to a multiple of the simd width so every
         // block starts aligned. cell_offsets maps a cell index to the offset
-        // of its block within local_vals_flat, or -1 for skipped cells.
+        // of its block within local_vals_flat, or -1 for skipped cells. It is
+        // sized nx*ny*nz from construction, and evaluate_inplace() clamps or
+        // rejects out-of-range cell indices, so lookups index it directly.
         AlignedPaddedVec local_vals_flat;
         std::vector<int64_t> cell_offsets;
         std::vector<bool> skip_cell; // whether to skip each cell or not
@@ -145,15 +147,6 @@ class RegularGridInterpolant3D {
         inline int idx_dof_local(int i, int j, int k) const {
             int degree = rule.degree;
             return i*(degree+1)*(degree+1) + j*(degree+1) + k;
-        }
-
-        // Offset of cell_idx's block in local_vals_flat, or -1 if that cell is
-        // skipped or the index is out of range. Callers may pass an index
-        // outside [0, nx*ny*nz) - see the clamping in evaluate_inplace().
-        inline int64_t cell_lookup(int cell_idx) const {
-            if(cell_idx < 0 || (size_t)cell_idx >= cell_offsets.size())
-                return -1;
-            return cell_offsets[cell_idx];
         }
 
         int locate_unsafe(double x, double y, double z);

--- a/src/firm3dpp/regular_grid_interpolant_3d.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d.h
@@ -111,13 +111,12 @@ class RegularGridInterpolant3D {
         // Per-cell storage used for evaluation. For each kept cell,
         // local_vals_flat holds a contiguous block of
         // (degree+1)^3 * value_size values (one entry per dof of the cell,
-        // dofs ordered by idx_dof_local, values contiguous per dof). Block
-        // lengths are rounded up to a multiple of the simd width so every
-        // block starts aligned. cell_offsets maps a cell index to the offset
-        // of its block within local_vals_flat, or -1 for skipped cells. It is
-        // sized nx*ny*nz from construction, and evaluate_inplace() clamps or
-        // rejects out-of-range cell indices, so lookups index it directly.
-        AlignedPaddedVec local_vals_flat;
+        // dofs ordered by idx_dof_local, values contiguous per dof).
+        // cell_offsets maps a cell index to the offset of its block within
+        // local_vals_flat, or -1 for skipped cells. It is sized nx*ny*nz from
+        // construction, and evaluate_inplace() clamps or rejects out-of-range
+        // cell indices, so lookups index it directly.
+        Vec local_vals_flat;
         std::vector<int64_t> cell_offsets;
         std::vector<bool> skip_cell; // whether to skip each cell or not
         // since we are skipping some dofs, we need mappings into the list of
@@ -128,7 +127,6 @@ class RegularGridInterpolant3D {
         uint32_t cells_to_skip, cells_to_keep, dofs_to_skip, dofs_to_keep; // which cells and dofs we skip and keep
         int local_vals_size; // length of each cell's block in local_vals_flat
 
-        static const int simdcount = xsimd::simd_type<double>::size; // vector width for simd instructions
         static const int MAX_NODES = 16; // upper bound on degree+1, so basis function values fit in stack buffers
 
         inline int idx_dof(int i, int j, int k) const {
@@ -296,11 +294,9 @@ class RegularGridInterpolant3D {
                 }
             }
 
-            // each cell's block holds (degree+1)^3 dofs with value_size values
-            // per dof; round the block length up to a multiple of the simd
-            // width so that every block in local_vals_flat starts aligned
-            int block = (degree+1)*(degree+1)*(degree+1)*value_size;
-            local_vals_size = ((block + simdcount - 1) / simdcount) * simdcount;
+            // each cell's block holds (degree+1)^3 dofs with value_size
+            // values per dof; the scalar kernels need no padding or alignment
+            local_vals_size = (degree+1)*(degree+1)*(degree+1)*value_size;
             cell_offsets.assign((size_t)nx*ny*nz, -1);
         }
         RegularGridInterpolant3D(InterpolationRule rule, RangeTriplet xrange, RangeTriplet yrange, RangeTriplet zrange, int value_size, bool out_of_bounds_ok) :

--- a/src/firm3dpp/regular_grid_interpolant_3d_impl.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d_impl.h
@@ -286,10 +286,6 @@ template<class Array>
 void RegularGridInterpolant3D<Array>::evaluate_local(double x, double y, double z, int cell_idx, double* res)
 {
     int degree = rule.degree;
-    // evaluate_inplace() clamps the cell indices into range when
-    // out_of_bounds_ok is set and throws otherwise, so cell_idx is always a
-    // valid index here. -1 marks a skipped cell (or an interpolant whose
-    // values have not been computed yet).
     int64_t flat_offset = cell_offsets[cell_idx];
     if (flat_offset < 0) {
         if(out_of_bounds_ok)

--- a/src/firm3dpp/regular_grid_interpolant_3d_impl.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d_impl.h
@@ -211,11 +211,11 @@ void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double y, doubl
     int zidx = int(nz*(z-zmin)/(zmax-zmin));
     if(!out_of_bounds_ok){
         if(xidx < 0 || xidx >= nx)
-            throw std::runtime_error((boost::format("xidxs={} not within [0, {}]") % xidx % (nx-1)).str());
+            throw std::runtime_error((boost::format("xidx=%d not within [0, %d]") % xidx % (nx-1)).str());
         if(yidx < 0 || yidx >= ny)
-            throw std::runtime_error((boost::format("yidxs={} not within [0, {}]") % yidx % (ny-1)).str());
+            throw std::runtime_error((boost::format("yidx=%d not within [0, %d]") % yidx % (ny-1)).str());
         if(zidx < 0 || zidx >= nz)
-            throw std::runtime_error((boost::format("zidxs={} not within [0, {}]") % zidx % (nz-1)).str());
+            throw std::runtime_error((boost::format("zidx=%d not within [0, %d]") % zidx % (nz-1)).str());
     } else {
         // Clamp cell indices to match CUDA kernel convention (cuda_kernel.cu:700-704).
         xidx = std::max(0, std::min(nx-1, xidx));
@@ -240,7 +240,7 @@ void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double* res){
 
     if(!out_of_bounds_ok){
         if(xidx < 0 || xidx >= nx)
-            throw std::runtime_error((boost::format("xidxs={} not within [0, {}]") % xidx % (nx-1)).str());
+            throw std::runtime_error((boost::format("xidx=%d not within [0, %d]") % xidx % (nx-1)).str());
     } else {
         // Clamp cell index (matching CUDA kernel behaviour): extrapolate from
         // last cell rather than returning zero.
@@ -293,10 +293,11 @@ template<class Array>
 void RegularGridInterpolant3D<Array>::evaluate_local(double x, double y, double z, int cell_idx, double* res)
 {
     int degree = rule.degree;
-    // cell_idx can be out of range: evaluate_inplace() clamps theta/zeta cell
-    // indices only from above, so a point below those ranges yields a negative
-    // index. Treat that like a skipped cell rather than indexing out of bounds.
-    int64_t flat_offset = cell_lookup(cell_idx);
+    // evaluate_inplace() clamps the cell indices into range when
+    // out_of_bounds_ok is set and throws otherwise, so cell_idx is always a
+    // valid index here. -1 marks a skipped cell (or an interpolant whose
+    // values have not been computed yet).
+    int64_t flat_offset = cell_offsets[cell_idx];
     if (flat_offset < 0) {
         if(out_of_bounds_ok)
             return;
@@ -332,8 +333,10 @@ void RegularGridInterpolant3D<Array>::evaluate_local(double x, double y, double 
         case 3: interp_cell_accumulate<3>(val_ptr, pkxs, pkys, pkzs, degree, res); return;
         case 4: interp_cell_accumulate<4>(val_ptr, pkxs, pkys, pkzs, degree, res); return;
     }
-    // general case: same nesting as above, with heap-free scratch sized at
-    // runtime from the caller's value_size
+    // general case (value_size > 4): same nesting as above, with scratch
+    // sized at runtime. The scratch vectors allocate on every call, which is
+    // acceptable because no field interpolant takes this path: everything in
+    // boozermagneticfield_interpolated.h has value_size <= 3.
     const double* __restrict vp = val_ptr;
     double* __restrict out = res;
     std::vector<double> sumj(value_size), sumk(value_size);
@@ -367,7 +370,7 @@ template<class Array>
 void RegularGridInterpolant3D<Array>::evaluate_local(double x, int cell_idx, double* res)
 {
     int degree = rule.degree;
-    int64_t flat_offset = cell_lookup(cell_idx);
+    int64_t flat_offset = cell_offsets[cell_idx];
     if (flat_offset < 0) {
         if(out_of_bounds_ok)
             return;

--- a/src/firm3dpp/regular_grid_interpolant_3d_impl.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d_impl.h
@@ -15,19 +15,84 @@
 template<class Array>
 const int RegularGridInterpolant3D<Array>::simdcount;
 
-// interpolate_batch is unchanged; set_interpolant_data (below) reuses the
-// all_local_vals_map rebuild logic but skips the function evaluation
+template<class Array>
+const int RegularGridInterpolant3D<Array>::MAX_NODES;
+
+// Copy the dof-ordered vals array into per-cell contiguous blocks
+// (local_vals_flat + cell_offsets), which is the storage evaluate_local()
+// reads. vals is freed afterwards; get_interpolant_data() reconstructs it
+// on demand via reconstruct_vals().
+template<class Array>
+void RegularGridInterpolant3D<Array>::build_local_vals() {
+    int degree = rule.degree;
+    cell_offsets.assign((size_t)nx*ny*nz, -1);
+    local_vals_flat = AlignedPaddedVec((size_t)cells_to_keep * local_vals_size, 0.);
+    int64_t flat_offset = 0;
+    for (int xidx = 0; xidx < nx; ++xidx) {
+        for (int yidx = 0; yidx < ny; ++yidx) {
+            for (int zidx = 0; zidx < nz; ++zidx) {
+                int meshidx = idx_cell(xidx, yidx, zidx);
+                if(skip_cell[meshidx])
+                    continue;
+                cell_offsets[meshidx] = flat_offset;
+                double* local_vals = local_vals_flat.data() + flat_offset;
+                for (int i = 0; i < degree+1; ++i) {
+                    for (int j = 0; j < degree+1; ++j) {
+                        for (int k = 0; k < degree+1; ++k) {
+                            size_t offset = (size_t)value_size*full_to_reduced_map[idx_dof(xidx*degree+i, yidx*degree+j, zidx*degree+k)];
+                            int offset_local = value_size * idx_dof_local(i, j, k);
+                            for (int l = 0; l < value_size; ++l) {
+                                local_vals[offset_local + l] = vals[offset + l];
+                            }
+                        }
+                    }
+                }
+                flat_offset += local_vals_size;
+            }
+        }
+    }
+    Vec().swap(vals);
+}
+
+template<class Array>
+Vec RegularGridInterpolant3D<Array>::reconstruct_vals() const {
+    int degree = rule.degree;
+    Vec v((size_t)dofs_to_keep * value_size, 0.);
+    for (int xidx = 0; xidx < nx; ++xidx) {
+        for (int yidx = 0; yidx < ny; ++yidx) {
+            for (int zidx = 0; zidx < nz; ++zidx) {
+                int64_t flat_offset = cell_offsets[idx_cell(xidx, yidx, zidx)];
+                if(flat_offset < 0)
+                    continue;
+                const double* local_vals = local_vals_flat.data() + flat_offset;
+                for (int i = 0; i < degree+1; ++i) {
+                    for (int j = 0; j < degree+1; ++j) {
+                        for (int k = 0; k < degree+1; ++k) {
+                            size_t offset = (size_t)value_size*full_to_reduced_map[idx_dof(xidx*degree+i, yidx*degree+j, zidx*degree+k)];
+                            int offset_local = value_size * idx_dof_local(i, j, k);
+                            for (int l = 0; l < value_size; ++l) {
+                                v[offset + l] = local_vals[offset_local + l];
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return v;
+}
+
 template<class Array>
 void RegularGridInterpolant3D<Array>::interpolate_batch(std::function<Vec(Vec, Vec, Vec)> &f) {
+    vals.assign((size_t)dofs_to_keep * value_size, 0.);
     int BATCH_SIZE = 16384;
     int NUM_BATCHES = dofs_to_keep/BATCH_SIZE + (dofs_to_keep % BATCH_SIZE != 0);
 
     for (int i = 0; i < NUM_BATCHES; ++i) {
         uint32_t first = i * BATCH_SIZE;
         uint32_t last = std::min((uint32_t)((i+1) * BATCH_SIZE), dofs_to_keep);
-        Vec xsub(xdoftensor_reduced.begin() + first, xdoftensor_reduced.begin() + last);
-        Vec ysub(ydoftensor_reduced.begin() + first, ydoftensor_reduced.begin() + last);
-        Vec zsub(zdoftensor_reduced.begin() + first, zdoftensor_reduced.begin() + last);
+        Vec xsub(last-first, 0.), ysub(last-first, 0.), zsub(last-first, 0.);
+        dof_coords(first, last, xsub, ysub, zsub);
         Vec fxyzsub  = f(xsub, ysub, zsub);
         for (int j = 0; j < last-first; ++j) {
             for (int l = 0; l < value_size; ++l) {
@@ -35,32 +100,7 @@ void RegularGridInterpolant3D<Array>::interpolate_batch(std::function<Vec(Vec, V
             }
         }
     }
-    int degree = rule.degree;
-    all_local_vals_map = std::unordered_map<int, AlignedPaddedVec>();
-    all_local_vals_map.reserve(cells_to_keep);
-
-    for (int xidx = 0; xidx < nx; ++xidx) {
-        for (int yidx = 0; yidx < ny; ++yidx) {
-            for (int zidx = 0; zidx < nz; ++zidx) {
-                int meshidx = idx_cell(xidx, yidx, zidx);
-                if(skip_cell[meshidx])
-                    continue;
-                AlignedPaddedVec local_vals(local_vals_size, 0.);
-                for (int i = 0; i < degree+1; ++i) {
-                    for (int j = 0; j < degree+1; ++j) {
-                        for (int k = 0; k < degree+1; ++k) {
-                            int offset = value_size*full_to_reduced_map[idx_dof(xidx*degree+i, yidx*degree+j, zidx*degree+k)];
-                            int offset_local = padded_value_size * idx_dof_local(i, j, k);
-                            for (int l = 0; l < value_size; ++l) {
-                                local_vals[offset_local + l] = vals[offset + l];
-                            }
-                        }
-                    }
-                }
-                all_local_vals_map.insert({meshidx, local_vals});
-            }
-        }
-    }
+    build_local_vals();
 }
 
 #ifdef USE_MPI
@@ -81,9 +121,8 @@ void RegularGridInterpolant3D<Array>::interpolate_batch(std::function<Vec(Vec, V
 
     for (int first = local_first; first < local_last; first += BATCH_SIZE) {
         int last = std::min(first + BATCH_SIZE, local_last);
-        Vec xsub(xdoftensor_reduced.begin() + first, xdoftensor_reduced.begin() + last);
-        Vec ysub(ydoftensor_reduced.begin() + first, ydoftensor_reduced.begin() + last);
-        Vec zsub(zdoftensor_reduced.begin() + first, zdoftensor_reduced.begin() + last);
+        Vec xsub(last-first, 0.), ysub(last-first, 0.), zsub(last-first, 0.);
+        dof_coords(first, last, xsub, ysub, zsub);
         Vec fxyzsub = f(xsub, ysub, zsub);
 
         int local_offset = (first - local_first) * value_size;
@@ -114,32 +153,8 @@ void RegularGridInterpolant3D<Array>::interpolate_batch(std::function<Vec(Vec, V
         MPI_DOUBLE,
         comm
     );
-    // Build all_local_vals_map (same on all ranks)
-    int degree = rule.degree;
-    all_local_vals_map = std::unordered_map<int, AlignedPaddedVec>();
-    all_local_vals_map.reserve(cells_to_keep);
-    for (int xidx = 0; xidx < nx; ++xidx) {
-        for (int yidx = 0; yidx < ny; ++yidx) {
-            for (int zidx = 0; zidx < nz; ++zidx) {
-                int meshidx = idx_cell(xidx, yidx, zidx);
-                if(skip_cell[meshidx])
-                    continue;
-                AlignedPaddedVec local_vals(local_vals_size, 0.);
-                for (int i = 0; i < degree+1; ++i) {
-                    for (int j = 0; j < degree+1; ++j) {
-                        for (int k = 0; k < degree+1; ++k) {
-                            int offset = value_size*full_to_reduced_map[idx_dof(xidx*degree+i, yidx*degree+j, zidx*degree+k)];
-                            int offset_local = padded_value_size * idx_dof_local(i, j, k);
-                            for (int l = 0; l < value_size; ++l) {
-                                local_vals[offset_local + l] = vals[offset + l];
-                            }
-                        }
-                    }
-                }
-                all_local_vals_map.insert({meshidx, local_vals});
-            }
-        }
-    }
+    // Build the per-cell evaluation storage (same on all ranks)
+    build_local_vals();
 }
 #endif
 
@@ -235,19 +250,61 @@ void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double* res){
     return evaluate_local(xlocal, idx_cell(xidx, 0, 0), res);
 }
 
+// Evaluate one cell: res[l] = sum_i p_i(x) [ sum_j p_j(y) [ sum_k p_k(z)
+// v[i,j,k,l] ] ], over the (degree+1)^3 dofs of the cell, whose values are
+// stored contiguously (VS per dof) at vp. The sum is nested in this order to
+// match what the previous SIMD implementation computed, so results stay
+// bit-for-bit identical; it also costs fewer multiplies than forming the
+// product p_i p_j p_k per dof. Compile-time VS lets the compiler unroll the
+// innermost loop and hold the accumulators in registers.
+template<int VS>
+static inline void interp_cell_accumulate(const double* __restrict vp, const double* pkxs, const double* pkys, const double* pkzs, int degree, double* __restrict res)
+{
+    double sumi[VS];
+    for (int l = 0; l < VS; ++l)
+        sumi[l] = 0.;
+    for (int i = 0; i < degree+1; ++i) {
+        double sumj[VS];
+        for (int l = 0; l < VS; ++l)
+            sumj[l] = 0.;
+        for (int j = 0; j < degree+1; ++j) {
+            double sumk[VS];
+            for (int l = 0; l < VS; ++l)
+                sumk[l] = 0.;
+            for (int k = 0; k < degree+1; ++k) {
+                double pkz = pkzs[k];
+                for (int l = 0; l < VS; ++l)
+                    sumk[l] += vp[l] * pkz;
+                vp += VS;
+            }
+            double pjy = pkys[j];
+            for (int l = 0; l < VS; ++l)
+                sumj[l] += sumk[l] * pjy;
+        }
+        double pix = pkxs[i];
+        for (int l = 0; l < VS; ++l)
+            sumi[l] += sumj[l] * pix;
+    }
+    for (int l = 0; l < VS; ++l)
+        res[l] = sumi[l];
+}
+
 template<class Array>
 void RegularGridInterpolant3D<Array>::evaluate_local(double x, double y, double z, int cell_idx, double* res)
 {
     int degree = rule.degree;
-    auto got = all_local_vals_map.find(cell_idx);
-    if (got == all_local_vals_map.end()) {
+    // cell_idx can be out of range: evaluate_inplace() clamps theta/zeta cell
+    // indices only from above, so a point below those ranges yields a negative
+    // index. Treat that like a skipped cell rather than indexing out of bounds.
+    int64_t flat_offset = cell_lookup(cell_idx);
+    if (flat_offset < 0) {
         if(out_of_bounds_ok)
             return;
         else
-            throw std::runtime_error((boost::format("cell_idx={} not in all_local_vals_map") % cell_idx).str());
+            throw std::runtime_error((boost::format("cell_idx=%d is outside the interpolation domain") % cell_idx).str());
     }
 
-    double* vals_local = got->second.data();
+    double pkxs[MAX_NODES], pkys[MAX_NODES], pkzs[MAX_NODES];
     if(xsimd::simd_type<double>::size >= 3){
         simd_t xyz;
         xyz[0] = x;
@@ -267,66 +324,74 @@ void RegularGridInterpolant3D<Array>::evaluate_local(double x, double y, double 
         }
     }
 
-    // Potential optimization: Use barycentric interpolation here. Right now, the
-    // implementation is O(degree^3) in memory and O(degree^4) in computation,
-    // using Barycentric interpolation this could be reduced to O(degree^3) in
-    // memory and O(degree^3) in computation.
-    for(int l=0; l<padded_value_size; l += simdcount) {
-        simd_t sumi(0.);
-        int offset_local = l;
-        double* val_ptr = &(vals_local[offset_local]);
-        for (int i = 0; i < degree+1; ++i) {
-            simd_t sumj(0.);
-            for (int j = 0; j < degree+1; ++j) {
-                simd_t sumk(0.);
-                for (int k = 0; k < degree+1; ++k) {
-                    double pkz = pkzs[k];
-                    sumk = xsimd::fma(xsimd::load_aligned(val_ptr), simd_t(pkz), sumk);
-                    val_ptr += padded_value_size;
+    const double* val_ptr = local_vals_flat.data() + flat_offset;
+    switch (value_size) {
+        // dispatch the common small sizes to compile-time kernels
+        case 1: interp_cell_accumulate<1>(val_ptr, pkxs, pkys, pkzs, degree, res); return;
+        case 2: interp_cell_accumulate<2>(val_ptr, pkxs, pkys, pkzs, degree, res); return;
+        case 3: interp_cell_accumulate<3>(val_ptr, pkxs, pkys, pkzs, degree, res); return;
+        case 4: interp_cell_accumulate<4>(val_ptr, pkxs, pkys, pkzs, degree, res); return;
+    }
+    // general case: same nesting as above, with heap-free scratch sized at
+    // runtime from the caller's value_size
+    const double* __restrict vp = val_ptr;
+    double* __restrict out = res;
+    std::vector<double> sumj(value_size), sumk(value_size);
+    for (int l = 0; l < value_size; ++l) {
+        out[l] = 0.;
+    }
+    for (int i = 0; i < degree+1; ++i) {
+        std::fill(sumj.begin(), sumj.end(), 0.);
+        for (int j = 0; j < degree+1; ++j) {
+            std::fill(sumk.begin(), sumk.end(), 0.);
+            for (int k = 0; k < degree+1; ++k) {
+                double pkz = pkzs[k];
+                for (int l = 0; l < value_size; ++l) {
+                    sumk[l] += vp[l] * pkz;
                 }
-                double pjy = pkys[j];
-                sumj = xsimd::fma(sumk, simd_t(pjy), sumj);
+                vp += value_size;
             }
-            double pix = pkxs[i];
-            sumi = xsimd::fma(sumj, simd_t(pix), sumi);
+            double pjy = pkys[j];
+            for (int l = 0; l < value_size; ++l) {
+                sumj[l] += sumk[l] * pjy;
+            }
         }
-        for (int ll = 0; ll < std::min(simdcount, value_size-l); ++ll) {
-            res[l+ll] = sumi[ll];
+        double pix = pkxs[i];
+        for (int l = 0; l < value_size; ++l) {
+            out[l] += sumj[l] * pix;
         }
     }
 }
-//TODO memory usage not fixed
 
 template<class Array>
 void RegularGridInterpolant3D<Array>::evaluate_local(double x, int cell_idx, double* res)
 {
     int degree = rule.degree;
-    auto got = all_local_vals_map.find(cell_idx);
-    if (got == all_local_vals_map.end()) {
+    int64_t flat_offset = cell_lookup(cell_idx);
+    if (flat_offset < 0) {
         if(out_of_bounds_ok)
             return;
         else
-            throw std::runtime_error((boost::format("cell_idx={} not in all_local_vals_map") % cell_idx).str());
+            throw std::runtime_error((boost::format("cell_idx=%d is outside the interpolation domain") % cell_idx).str());
     }
 
-    double* vals_local = got->second.data();
-
+    double pkxs[MAX_NODES];
     for (int k = 0; k < degree+1; ++k) {
         pkxs[k] = this->rule.basis_fun(k, x);
     }
 
-    for(int l=0; l<padded_value_size; l += simdcount) {
-        simd_t sumi(0.);
-        int offset_local = l;
-        double* val_ptr = &(vals_local[offset_local]);
-        for (int i = 0; i < degree+1; ++i) {
-            double pkx = pkxs[i];
-            sumi = xsimd::fma(xsimd::load_aligned(val_ptr), simd_t(pkx), sumi);
-            val_ptr += padded_value_size * (degree+1) * (degree+1);
+    // 1D interpolation along x through the (j=0, k=0) dofs of the cell block
+    const double* val_ptr = local_vals_flat.data() + flat_offset;
+    int stride = (degree+1)*(degree+1)*value_size;
+    for (int l = 0; l < value_size; ++l) {
+        res[l] = 0.;
+    }
+    for (int i = 0; i < degree+1; ++i) {
+        double pkx = pkxs[i];
+        for (int l = 0; l < value_size; ++l) {
+            res[l] += pkx * val_ptr[l];
         }
-        for (int ll = 0; ll < std::min(simdcount, value_size-l); ++ll) {
-            res[l+ll] = sumi[ll];
-        }
+        val_ptr += stride;
     }
 }
 
@@ -384,7 +449,7 @@ Vec linspace(double min, double max, int n, bool endpoint) {
 template<class Array>
 std::map<std::string, std::vector<double>> RegularGridInterpolant3D<Array>::get_interpolant_data() const {
     std::map<std::string, std::vector<double>> data;
-    data["vals"] = vals;
+    data["vals"] = reconstruct_vals();
     data["nx"] = {static_cast<double>(nx)};
     data["ny"] = {static_cast<double>(ny)};
     data["nz"] = {static_cast<double>(nz)};
@@ -407,37 +472,14 @@ void RegularGridInterpolant3D<Array>::set_interpolant_data(const std::map<std::s
     // Look up "vals" in the map. find() returns an iterator pointing to a
     // std::pair<key, value>. Access the value via .second (key is .first).
     auto it = data.find("vals");
-    if (it != data.end()) {
-        vals = it->second;
-    }
+    if (it == data.end())
+        throw std::runtime_error("set_interpolant_data: no 'vals' entry in data");
+    if (it->second.size() != (size_t)dofs_to_keep * value_size)
+        throw std::runtime_error((boost::format("set_interpolant_data: 'vals' has size %d but this grid needs %d") % it->second.size() % ((size_t)dofs_to_keep * value_size)).str());
+    vals = it->second;
 
-    // Rebuild all_local_vals_map from vals. This is the cell-indexed lookup table
-    // used by evaluate_local() - same construction as interpolate_batch() but
-    // without calling the function to compute values.
-    int degree = rule.degree;
-    all_local_vals_map = std::unordered_map<int, AlignedPaddedVec>();
-    all_local_vals_map.reserve(cells_to_keep);
-
-    for (int xidx = 0; xidx < nx; ++xidx) {
-        for (int yidx = 0; yidx < ny; ++yidx) {
-            for (int zidx = 0; zidx < nz; ++zidx) {
-                int meshidx = idx_cell(xidx, yidx, zidx);
-                if(skip_cell[meshidx])
-                    continue;
-                AlignedPaddedVec local_vals(local_vals_size, 0.);
-                for (int i = 0; i < degree+1; ++i) {
-                    for (int j = 0; j < degree+1; ++j) {
-                        for (int k = 0; k < degree+1; ++k) {
-                            int offset = value_size*full_to_reduced_map[idx_dof(xidx*degree+i, yidx*degree+j, zidx*degree+k)];
-                            int offset_local = padded_value_size * idx_dof_local(i, j, k);
-                            for (int l = 0; l < value_size; ++l) {
-                                local_vals[offset_local + l] = vals[offset + l];
-                            }
-                        }
-                    }
-                }
-                all_local_vals_map.insert({meshidx, local_vals});
-            }
-        }
-    }
+    // Rebuild the cell-indexed evaluation storage from vals - same
+    // construction as interpolate_batch() but without calling the function
+    // to compute values.
+    build_local_vals();
 }

--- a/src/firm3dpp/regular_grid_interpolant_3d_impl.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d_impl.h
@@ -249,11 +249,7 @@ void RegularGridInterpolant3D<Array>::evaluate_inplace(double x, double* res){
 
 // Evaluate one cell: res[l] = sum_i p_i(x) [ sum_j p_j(y) [ sum_k p_k(z)
 // v[i,j,k,l] ] ], over the (degree+1)^3 dofs of the cell, whose values are
-// stored contiguously (VS per dof) at vp. The sum is nested in this order to
-// match what the previous SIMD implementation computed, so results stay
-// bit-for-bit identical; it also costs fewer multiplies than forming the
-// product p_i p_j p_k per dof. Compile-time VS lets the compiler unroll the
-// innermost loop and hold the accumulators in registers.
+// stored contiguously (VS per dof) at vp.
 template<int VS>
 static inline void interp_cell_accumulate(const double* __restrict vp, const double* pkxs, const double* pkys, const double* pkzs, int degree, double* __restrict res)
 {

--- a/src/firm3dpp/regular_grid_interpolant_3d_impl.h
+++ b/src/firm3dpp/regular_grid_interpolant_3d_impl.h
@@ -13,9 +13,6 @@
 #define _EPS_ 1e-13
 
 template<class Array>
-const int RegularGridInterpolant3D<Array>::simdcount;
-
-template<class Array>
 const int RegularGridInterpolant3D<Array>::MAX_NODES;
 
 // Copy the dof-ordered vals array into per-cell contiguous blocks
@@ -26,7 +23,7 @@ template<class Array>
 void RegularGridInterpolant3D<Array>::build_local_vals() {
     int degree = rule.degree;
     cell_offsets.assign((size_t)nx*ny*nz, -1);
-    local_vals_flat = AlignedPaddedVec((size_t)cells_to_keep * local_vals_size, 0.);
+    local_vals_flat.assign((size_t)cells_to_keep * local_vals_size, 0.);
     int64_t flat_offset = 0;
     for (int xidx = 0; xidx < nx; ++xidx) {
         for (int yidx = 0; yidx < ny; ++yidx) {

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -1008,15 +1008,9 @@ class TestingFiniteBeta(unittest.TestCase):
 
 class TestingRegularGridInterpolantStorage(unittest.TestCase):
     """
-    Tests for how RegularGridInterpolant3D stores its coefficients.
-
-    The values of every cell live in one flat array indexed through
-    cell_offsets, and the dof-ordered ``vals`` array is released once that has
-    been built. These check the paths that depend on the layout: evaluation for
-    each value_size that selects a different kernel, out-of-domain lookups,
-    the compaction of the flat array when cells are skipped, and the
-    serialisation round-trip, which has to rebuild ``vals`` from the per-cell
-    storage.
+    Tests for the flat per-cell storage of RegularGridInterpolant3D: kernel
+    dispatch per value_size, out-of-domain lookups, skip-cell compaction, and
+    the serialisation round-trip that rebuilds the transient ``vals`` array.
     """
 
     RANGE = (0.0, 1.0, 8)
@@ -1025,17 +1019,16 @@ class TestingRegularGridInterpolantStorage(unittest.TestCase):
         self, f, value_size, degree=3, out_of_bounds_ok=True, skip=None, grid=None
     ):
         grid = self.RANGE if grid is None else grid
-        args = [
+        skip = skip or (lambda xs, ys, zs: [False] * len(xs))
+        interp = RegularGridInterpolant3D(
             UniformInterpolationRule(degree),
             grid,
             grid,
             grid,
             value_size,
             out_of_bounds_ok,
-        ]
-        if skip is not None:
-            args.append(skip)
-        interp = RegularGridInterpolant3D(*args)
+            skip,
+        )
         interp.interpolate_batch(
             lambda x, y, z: (
                 f(np.asarray(x), np.asarray(y), np.asarray(z)).flatten().tolist()
@@ -1045,8 +1038,7 @@ class TestingRegularGridInterpolantStorage(unittest.TestCase):
 
     @staticmethod
     def _f(value_size):
-        # separable and linear in each argument, so the degree-3 rule
-        # reproduces it exactly and the expected values are known in closed form
+        # linear in each argument, so every rule reproduces it exactly
         def f(x, y, z):
             return np.stack([(l + 1) * (x + y + z) + l for l in range(value_size)], -1)
 
@@ -1054,186 +1046,100 @@ class TestingRegularGridInterpolantStorage(unittest.TestCase):
 
     def test_evaluate_exact_for_each_value_size(self):
         """value_size 1-4 use per-size kernels and 5+ the general one."""
-        rng = np.random.default_rng(3)
-        pts = np.ascontiguousarray(rng.uniform(0.02, 0.98, (200, 3)))
-        for value_size in (1, 2, 3, 4, 5, 7):
+        pts = np.random.default_rng(3).uniform(0.02, 0.98, (200, 3))
+        for value_size in (1, 2, 3, 4, 5):
             with self.subTest(value_size=value_size):
                 f = self._f(value_size)
                 interp = self._build(f, value_size)
-                out = np.zeros((pts.shape[0], value_size))
+                out = np.zeros((200, value_size))
                 interp.evaluate_batch(pts, out)
                 np.testing.assert_allclose(
                     out, f(pts[:, 0], pts[:, 1], pts[:, 2]), atol=1e-10
                 )
 
-    def test_roundtrip_through_interpolant_data(self):
+    def test_out_of_domain(self):
         """
-        get_interpolant_data has to rebuild the dof-ordered array from the
-        per-cell storage, since it is no longer retained after construction.
-        Feeding it back must give an interpolant that evaluates identically.
+        out_of_bounds_ok=True clamps the cell indices into range and keeps the
+        true local coordinate, extrapolating the boundary cell's polynomial -
+        exact for the linear test function, and what lets the flat storage be
+        indexed unchecked. out_of_bounds_ok=False raises instead.
         """
-        for value_size in (1, 3):
-            with self.subTest(value_size=value_size):
-                src = self._build(self._f(value_size), value_size)
-                dst = RegularGridInterpolant3D(
-                    UniformInterpolationRule(3),
-                    self.RANGE,
-                    self.RANGE,
-                    self.RANGE,
-                    value_size,
-                    True,
-                )
-                dst.set_interpolant_data(src.get_interpolant_data())
-
-                pts = np.ascontiguousarray(
-                    np.random.default_rng(0).uniform(0.02, 0.98, (500, 3))
-                )
-                a = np.zeros((500, value_size))
-                b = np.zeros((500, value_size))
-                src.evaluate_batch(pts, a)
-                dst.evaluate_batch(pts, b)
-                np.testing.assert_array_equal(a, b)
-                np.testing.assert_array_equal(
-                    src.get_interpolant_data()["vals"],
-                    dst.get_interpolant_data()["vals"],
-                )
-
-    def test_out_of_domain_clamped_to_boundary_cell(self):
-        """
-        With out_of_bounds_ok=True, evaluate_inplace clamps all three cell
-        indices into range while keeping the true local coordinate, so a point
-        outside the grid extrapolates the boundary cell's polynomial. The
-        clamping is what lets the flat storage be indexed without a bounds
-        check, so this locks the path that would otherwise read out of range.
-        The test function is linear and extrapolation of it is exact.
-        """
-        value_size = 2
-        f = self._f(value_size)
-        interp = self._build(f, value_size)
-        pts = np.ascontiguousarray(
-            [
-                [-0.4, 0.5, 0.5],
-                [1.4, 0.5, 0.5],
-                [0.5, -0.4, 0.5],
-                [0.5, 1.4, 0.5],
-                [0.5, 0.5, -0.4],
-                [0.5, 0.5, 1.4],
-                [-0.4, -0.4, -0.4],
-                [1.4, 1.4, 1.4],
-            ]
-        )
-        out = np.zeros((pts.shape[0], value_size))
+        f = self._f(2)
+        interp = self._build(f, 2)
+        pts = np.array([[-0.4] * 3, [1.4] * 3, [-0.4, 1.4, 0.5]])
+        out = np.zeros((3, 2))
         interp.evaluate_batch(pts, out)
-        # extrapolation of a linear function is exact analytically, but the
-        # Lagrange basis several cells outside a corner cancels catastrophically,
-        # which limits the achievable precision to ~1e-7 here
+        # far-corner extrapolation cancels catastrophically: ~1e-7 attainable
         np.testing.assert_allclose(
             out, f(pts[:, 0], pts[:, 1], pts[:, 2]), rtol=0.0, atol=1e-5
         )
-
-    def test_out_of_domain_raises_when_not_ok(self):
-        """With out_of_bounds_ok=False an out-of-range point is an error."""
-        f = self._f(1)
-        interp = self._build(f, 1, out_of_bounds_ok=False)
-        out = np.zeros((1, 1))
-        interp.evaluate_batch(np.ascontiguousarray([[0.5, 0.5, 0.5]]), out)
-        np.testing.assert_allclose(out[0], f(0.5, 0.5, 0.5), atol=1e-10)
+        strict = self._build(self._f(1), 1, out_of_bounds_ok=False)
+        strict.evaluate_batch(np.array([[0.5] * 3]), np.zeros((1, 1)))  # in range: fine
         for bad in ([-0.5, 0.5, 0.5], [0.5, 1.5, 0.5], [0.5, 0.5, -0.5]):
             with self.assertRaisesRegex(RuntimeError, "not within", msg=str(bad)):
-                interp.evaluate_batch(np.ascontiguousarray([bad]), np.zeros((1, 1)))
+                strict.evaluate_batch(np.array([bad]), np.zeros((1, 1)))
 
-    def test_skipped_cells(self):
+    def test_skipped_cells_and_roundtrip(self):
         """
-        Cells whose corners all satisfy the skip function get no block in the
-        flat storage, so the kept blocks are compacted and cell_offsets holds
-        -1 for the skipped cells. Points in kept cells must evaluate exactly,
-        points in skipped cells must leave the output untouched
-        (out_of_bounds_ok=True) or raise (out_of_bounds_ok=False), and the
-        serialisation round-trip must survive the compaction, since vals then
-        covers only the kept dofs.
+        Cells whose corners all satisfy skip get no block: kept blocks are
+        compacted and cell_offsets holds -1 for them. The round-trip has to
+        rebuild the reduced ``vals`` from that compacted storage.
         """
-        value_size = 2
-        f = self._f(value_size)
+        vs, R = 2, self.RANGE
+        f = self._f(vs)
 
         def skip(xs, ys, zs):
+            # with R's 8 cells this skips the three cells with x >= 0.625
             return [x > 0.5 for x in xs]
 
-        # with RANGE's 8 cells, the cells [0.625, 0.75], [0.75, 0.875] and
-        # [0.875, 1.0] have all corners at x > 0.5 and are skipped
-        interp = self._build(f, value_size, skip=skip)
-        rng = np.random.default_rng(5)
-        kept = np.ascontiguousarray(
-            np.stack(
-                [
-                    rng.uniform(0.02, 0.60, 100),
-                    rng.uniform(0.02, 0.98, 100),
-                    rng.uniform(0.02, 0.98, 100),
-                ],
-                axis=-1,
-            )
+        interp = self._build(f, vs, skip=skip)
+        kept = np.random.default_rng(5).uniform(
+            [0.02] * 3, [0.60, 0.98, 0.98], (100, 3)
         )
-        out = np.zeros((kept.shape[0], value_size))
+        out = np.zeros((100, vs))
         interp.evaluate_batch(kept, out)
         np.testing.assert_allclose(
             out, f(kept[:, 0], kept[:, 1], kept[:, 2]), atol=1e-10
         )
 
-        skipped = kept.copy()
-        skipped[:, 0] = rng.uniform(0.65, 0.98, kept.shape[0])
-        sentinel = np.full((skipped.shape[0], value_size), 7.0)
+        # a skipped cell leaves the output untouched, or raises in strict mode
+        skipped = np.array([[0.7, 0.5, 0.5]])
+        sentinel = np.full((1, vs), 7.0)
         interp.evaluate_batch(skipped, sentinel)
         np.testing.assert_array_equal(sentinel, 7.0)
-
-        strict = self._build(f, value_size, out_of_bounds_ok=False, skip=skip)
+        strict = self._build(f, vs, out_of_bounds_ok=False, skip=skip)
         with self.assertRaisesRegex(RuntimeError, "outside the interpolation domain"):
-            strict.evaluate_batch(
-                np.ascontiguousarray([[0.7, 0.5, 0.5]]),
-                np.zeros((1, value_size)),
-            )
+            strict.evaluate_batch(skipped, np.zeros((1, vs)))
 
         dst = RegularGridInterpolant3D(
-            UniformInterpolationRule(3),
-            self.RANGE,
-            self.RANGE,
-            self.RANGE,
-            value_size,
-            True,
-            skip,
+            UniformInterpolationRule(3), R, R, R, vs, True, skip
         )
-        dst.set_interpolant_data(interp.get_interpolant_data())
+        data = interp.get_interpolant_data()
+        dst.set_interpolant_data(data)
+        np.testing.assert_array_equal(data["vals"], dst.get_interpolant_data()["vals"])
         out_dst = np.zeros_like(out)
         dst.evaluate_batch(kept, out_dst)
         np.testing.assert_array_equal(out, out_dst)
 
     def test_degree_cap(self):
-        """
-        Basis-function values live in stack buffers of MAX_NODES = 16 entries,
-        so the constructor accepts degree 15 and rejects degree 16.
-        """
+        """MAX_NODES = 16 stack buffers: degree 15 works, degree 16 throws."""
         tiny = (0.0, 1.0, 2)
-        f = self._f(1)
-        interp = self._build(f, 1, degree=15, grid=tiny)
-        pts = np.ascontiguousarray(
-            np.random.default_rng(7).uniform(0.02, 0.98, (50, 3))
-        )
-        out = np.zeros((pts.shape[0], 1))
+        interp = self._build(self._f(1), 1, degree=15, grid=tiny)
+        pts = np.random.default_rng(7).uniform(0.02, 0.98, (20, 3))
+        out = np.zeros((20, 1))
         interp.evaluate_batch(pts, out)
-        np.testing.assert_allclose(out, f(pts[:, 0], pts[:, 1], pts[:, 2]), atol=1e-8)
-
+        np.testing.assert_allclose(out[:, 0], pts.sum(axis=1), atol=1e-8)
         with self.assertRaises(ValueError):
             RegularGridInterpolant3D(
                 UniformInterpolationRule(16), tiny, tiny, tiny, 1, True
             )
 
-    def test_set_interpolant_data_rejects_wrong_size(self):
-        interp = self._build(self._f(1), 1)
-        with self.assertRaisesRegex(RuntimeError, "'vals' has size"):
-            interp.set_interpolant_data({"vals": [1.0, 2.0]})
-
-    def test_set_interpolant_data_requires_vals(self):
+    def test_set_interpolant_data_validates_input(self):
         interp = self._build(self._f(1), 1)
         with self.assertRaisesRegex(RuntimeError, "no 'vals' entry"):
             interp.set_interpolant_data({"nx": [8.0]})
+        with self.assertRaisesRegex(RuntimeError, "'vals' has size"):
+            interp.set_interpolant_data({"vals": [1.0, 2.0]})
 
 
 class TestingInverseFourier(unittest.TestCase):

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -17,7 +17,12 @@ from firm3d.field.boozermagneticfield import (
     ShearAlfvenWavesSuperposition,
 )
 from firm3d.saw.ae3d import AE3DEigenvector
-from firm3dpp import inverse_fourier_transform_even, inverse_fourier_transform_odd
+from firm3dpp import (
+    RegularGridInterpolant3D,
+    UniformInterpolationRule,
+    inverse_fourier_transform_even,
+    inverse_fourier_transform_odd,
+)
 
 TEST_DIR = (Path(__file__).parent / ".." / "test_files").resolve()
 filename_vac = str((TEST_DIR / "boozmn_LandremanPaul2021_QA_lowres.nc").resolve())
@@ -999,6 +1004,92 @@ class TestingFiniteBeta(unittest.TestCase):
             old_err_Z = err_Z
             old_err_nu = err_nu
             old_err_K = err_K
+
+
+class TestingRegularGridInterpolantStorage(unittest.TestCase):
+    """
+    Tests for how RegularGridInterpolant3D stores its coefficients.
+
+    The values of every cell live in one flat array indexed through
+    cell_offsets, and the dof-ordered ``vals`` array is released once that has
+    been built. These check the paths that depend on the layout: evaluation for
+    each value_size that selects a different kernel, and the serialisation
+    round-trip, which has to rebuild ``vals`` from the per-cell storage.
+    """
+
+    RANGE = (0.0, 1.0, 8)
+
+    def _build(self, f, value_size, degree=3, out_of_bounds_ok=True):
+        interp = RegularGridInterpolant3D(
+            UniformInterpolationRule(degree),
+            self.RANGE,
+            self.RANGE,
+            self.RANGE,
+            value_size,
+            out_of_bounds_ok,
+        )
+        interp.interpolate_batch(
+            lambda x, y, z: (
+                f(np.asarray(x), np.asarray(y), np.asarray(z)).flatten().tolist()
+            )
+        )
+        return interp
+
+    @staticmethod
+    def _f(value_size):
+        # separable and linear in each argument, so the degree-3 rule
+        # reproduces it exactly and the expected values are known in closed form
+        def f(x, y, z):
+            return np.stack([(l + 1) * (x + y + z) + l for l in range(value_size)], -1)
+
+        return f
+
+    def test_evaluate_exact_for_each_value_size(self):
+        """value_size 1-4 use per-size kernels and 5+ the general one."""
+        rng = np.random.default_rng(3)
+        pts = np.ascontiguousarray(rng.uniform(0.02, 0.98, (200, 3)))
+        for value_size in (1, 2, 3, 4, 5, 7):
+            with self.subTest(value_size=value_size):
+                f = self._f(value_size)
+                interp = self._build(f, value_size)
+                out = np.zeros((pts.shape[0], value_size))
+                interp.evaluate_batch(pts, out)
+                np.testing.assert_allclose(
+                    out, f(pts[:, 0], pts[:, 1], pts[:, 2]), atol=1e-10
+                )
+
+    def test_roundtrip_through_interpolant_data(self):
+        """
+        get_interpolant_data has to rebuild the dof-ordered array from the
+        per-cell storage, since it is no longer retained after construction.
+        Feeding it back must give an interpolant that evaluates identically.
+        """
+        for value_size in (1, 3):
+            with self.subTest(value_size=value_size):
+                src = self._build(self._f(value_size), value_size)
+                dst = RegularGridInterpolant3D(
+                    UniformInterpolationRule(3),
+                    self.RANGE,
+                    self.RANGE,
+                    self.RANGE,
+                    value_size,
+                    True,
+                )
+                dst.set_interpolant_data(src.get_interpolant_data())
+
+                pts = np.ascontiguousarray(
+                    np.random.default_rng(0).uniform(0.02, 0.98, (500, 3))
+                )
+                a = np.zeros((500, value_size))
+                b = np.zeros((500, value_size))
+                src.evaluate_batch(pts, a)
+                dst.evaluate_batch(pts, b)
+                np.testing.assert_array_equal(a, b)
+
+    def test_set_interpolant_data_rejects_wrong_size(self):
+        interp = self._build(self._f(1), 1)
+        with self.assertRaises(RuntimeError):
+            interp.set_interpolant_data({"vals": [1.0, 2.0]})
 
 
 class TestingInverseFourier(unittest.TestCase):

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -1013,21 +1013,29 @@ class TestingRegularGridInterpolantStorage(unittest.TestCase):
     The values of every cell live in one flat array indexed through
     cell_offsets, and the dof-ordered ``vals`` array is released once that has
     been built. These check the paths that depend on the layout: evaluation for
-    each value_size that selects a different kernel, and the serialisation
-    round-trip, which has to rebuild ``vals`` from the per-cell storage.
+    each value_size that selects a different kernel, out-of-domain lookups,
+    the compaction of the flat array when cells are skipped, and the
+    serialisation round-trip, which has to rebuild ``vals`` from the per-cell
+    storage.
     """
 
     RANGE = (0.0, 1.0, 8)
 
-    def _build(self, f, value_size, degree=3, out_of_bounds_ok=True):
-        interp = RegularGridInterpolant3D(
+    def _build(
+        self, f, value_size, degree=3, out_of_bounds_ok=True, skip=None, grid=None
+    ):
+        grid = self.RANGE if grid is None else grid
+        args = [
             UniformInterpolationRule(degree),
-            self.RANGE,
-            self.RANGE,
-            self.RANGE,
+            grid,
+            grid,
+            grid,
             value_size,
             out_of_bounds_ok,
-        )
+        ]
+        if skip is not None:
+            args.append(skip)
+        interp = RegularGridInterpolant3D(*args)
         interp.interpolate_batch(
             lambda x, y, z: (
                 f(np.asarray(x), np.asarray(y), np.asarray(z)).flatten().tolist()
@@ -1085,11 +1093,147 @@ class TestingRegularGridInterpolantStorage(unittest.TestCase):
                 src.evaluate_batch(pts, a)
                 dst.evaluate_batch(pts, b)
                 np.testing.assert_array_equal(a, b)
+                np.testing.assert_array_equal(
+                    src.get_interpolant_data()["vals"],
+                    dst.get_interpolant_data()["vals"],
+                )
+
+    def test_out_of_domain_clamped_to_boundary_cell(self):
+        """
+        With out_of_bounds_ok=True, evaluate_inplace clamps all three cell
+        indices into range while keeping the true local coordinate, so a point
+        outside the grid extrapolates the boundary cell's polynomial. The
+        clamping is what lets the flat storage be indexed without a bounds
+        check, so this locks the path that would otherwise read out of range.
+        The test function is linear and extrapolation of it is exact.
+        """
+        value_size = 2
+        f = self._f(value_size)
+        interp = self._build(f, value_size)
+        pts = np.ascontiguousarray(
+            [
+                [-0.4, 0.5, 0.5],
+                [1.4, 0.5, 0.5],
+                [0.5, -0.4, 0.5],
+                [0.5, 1.4, 0.5],
+                [0.5, 0.5, -0.4],
+                [0.5, 0.5, 1.4],
+                [-0.4, -0.4, -0.4],
+                [1.4, 1.4, 1.4],
+            ]
+        )
+        out = np.zeros((pts.shape[0], value_size))
+        interp.evaluate_batch(pts, out)
+        # extrapolation of a linear function is exact analytically, but the
+        # Lagrange basis several cells outside a corner cancels catastrophically,
+        # which limits the achievable precision to ~1e-7 here
+        np.testing.assert_allclose(
+            out, f(pts[:, 0], pts[:, 1], pts[:, 2]), rtol=0.0, atol=1e-5
+        )
+
+    def test_out_of_domain_raises_when_not_ok(self):
+        """With out_of_bounds_ok=False an out-of-range point is an error."""
+        f = self._f(1)
+        interp = self._build(f, 1, out_of_bounds_ok=False)
+        out = np.zeros((1, 1))
+        interp.evaluate_batch(np.ascontiguousarray([[0.5, 0.5, 0.5]]), out)
+        np.testing.assert_allclose(out[0], f(0.5, 0.5, 0.5), atol=1e-10)
+        for bad in ([-0.5, 0.5, 0.5], [0.5, 1.5, 0.5], [0.5, 0.5, -0.5]):
+            with self.assertRaisesRegex(RuntimeError, "not within", msg=str(bad)):
+                interp.evaluate_batch(np.ascontiguousarray([bad]), np.zeros((1, 1)))
+
+    def test_skipped_cells(self):
+        """
+        Cells whose corners all satisfy the skip function get no block in the
+        flat storage, so the kept blocks are compacted and cell_offsets holds
+        -1 for the skipped cells. Points in kept cells must evaluate exactly,
+        points in skipped cells must leave the output untouched
+        (out_of_bounds_ok=True) or raise (out_of_bounds_ok=False), and the
+        serialisation round-trip must survive the compaction, since vals then
+        covers only the kept dofs.
+        """
+        value_size = 2
+        f = self._f(value_size)
+
+        def skip(xs, ys, zs):
+            return [x > 0.5 for x in xs]
+
+        # with RANGE's 8 cells, the cells [0.625, 0.75], [0.75, 0.875] and
+        # [0.875, 1.0] have all corners at x > 0.5 and are skipped
+        interp = self._build(f, value_size, skip=skip)
+        rng = np.random.default_rng(5)
+        kept = np.ascontiguousarray(
+            np.stack(
+                [
+                    rng.uniform(0.02, 0.60, 100),
+                    rng.uniform(0.02, 0.98, 100),
+                    rng.uniform(0.02, 0.98, 100),
+                ],
+                axis=-1,
+            )
+        )
+        out = np.zeros((kept.shape[0], value_size))
+        interp.evaluate_batch(kept, out)
+        np.testing.assert_allclose(
+            out, f(kept[:, 0], kept[:, 1], kept[:, 2]), atol=1e-10
+        )
+
+        skipped = kept.copy()
+        skipped[:, 0] = rng.uniform(0.65, 0.98, kept.shape[0])
+        sentinel = np.full((skipped.shape[0], value_size), 7.0)
+        interp.evaluate_batch(skipped, sentinel)
+        np.testing.assert_array_equal(sentinel, 7.0)
+
+        strict = self._build(f, value_size, out_of_bounds_ok=False, skip=skip)
+        with self.assertRaisesRegex(RuntimeError, "outside the interpolation domain"):
+            strict.evaluate_batch(
+                np.ascontiguousarray([[0.7, 0.5, 0.5]]),
+                np.zeros((1, value_size)),
+            )
+
+        dst = RegularGridInterpolant3D(
+            UniformInterpolationRule(3),
+            self.RANGE,
+            self.RANGE,
+            self.RANGE,
+            value_size,
+            True,
+            skip,
+        )
+        dst.set_interpolant_data(interp.get_interpolant_data())
+        out_dst = np.zeros_like(out)
+        dst.evaluate_batch(kept, out_dst)
+        np.testing.assert_array_equal(out, out_dst)
+
+    def test_degree_cap(self):
+        """
+        Basis-function values live in stack buffers of MAX_NODES = 16 entries,
+        so the constructor accepts degree 15 and rejects degree 16.
+        """
+        tiny = (0.0, 1.0, 2)
+        f = self._f(1)
+        interp = self._build(f, 1, degree=15, grid=tiny)
+        pts = np.ascontiguousarray(
+            np.random.default_rng(7).uniform(0.02, 0.98, (50, 3))
+        )
+        out = np.zeros((pts.shape[0], 1))
+        interp.evaluate_batch(pts, out)
+        np.testing.assert_allclose(out, f(pts[:, 0], pts[:, 1], pts[:, 2]), atol=1e-8)
+
+        with self.assertRaises(ValueError):
+            RegularGridInterpolant3D(
+                UniformInterpolationRule(16), tiny, tiny, tiny, 1, True
+            )
 
     def test_set_interpolant_data_rejects_wrong_size(self):
         interp = self._build(self._f(1), 1)
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesRegex(RuntimeError, "'vals' has size"):
             interp.set_interpolant_data({"vals": [1.0, 2.0]})
+
+    def test_set_interpolant_data_requires_vals(self):
+        interp = self._build(self._f(1), 1)
+        with self.assertRaisesRegex(RuntimeError, "no 'vals' entry"):
+            interp.set_interpolant_data({"nx": [8.0]})
 
 
 class TestingInverseFourier(unittest.TestCase):


### PR DESCRIPTION
RegularGridInterpolant3D stored each cell's coefficients in its own heap-allocated vector inside an unordered_map, padded per dof to a multiple of the SIMD width, and kept the dof-ordered vals array alongside it for the interpolant's lifetime. For a scalar quantity on AVX2 that is four doubles of storage per one double of data, plus a malloc header and a map node per cell, plus a second full copy of the values.

Store the cells in one flat array indexed by an offset table instead, with no per-dof padding, and release vals once that has been built (get_interpolant_data rebuilds it on demand for serialisation). The tensor-product dof coordinate arrays are computed during construction rather than stored.

Evaluation reads the same values with the same summation nesting, so results are unchanged; the SIMD-over-padding kernel becomes scalar loops over contiguous per-cell blocks, dispatched on value_size. Measured slightly faster, since a cell now spans fewer cache lines.

A flat array cannot absorb an out-of-range cell index the way a hash lookup did. Since #68, evaluate_inplace clamps all three cell indices into range (or throws when out_of_bounds_ok is false), so the offset table is indexed directly; its -1 entries mark skipped cells.

On a Perlmutter CPU node, tracing a fusion alpha birth distribution at interpolation resolution 96, this takes the field from 6.3 GB to 2.9 GB per rank, which raises the usable rank count from 72 to all 128 cores and gives 1.88x the throughput of the best configuration that fits without it.

## Summary by Sourcery

Flatten RegularGridInterpolant3D’s per-cell data and eliminate redundant persistent arrays to substantially reduce field memory usage without changing interpolation results.

Bug Fixes:
- Preserve interpolation behavior for skipped cells, out-of-domain evaluation, and serialized interpolants while adding validation for malformed serialized data.

Enhancements:
- Reduce RegularGridInterpolant3D memory usage by replacing padded per-cell hash-map allocations and persistent coordinate/value copies with compact flat cell storage and on-demand reconstruction.
- Update evaluation to use contiguous per-cell data with value-size dispatch while retaining the existing interpolation results and supporting degrees up to 15.

Tests:
- Add coverage for value-size-specific evaluation, boundary handling, skipped cells, serialization round trips, degree limits, and input validation.
