### PR TITLE
Find header-only Boost installs that ship no CMake config

### DIFF
--- a/.github/scripts/setup_ci_env.sh
+++ b/.github/scripts/setup_ci_env.sh
@@ -22,6 +22,9 @@ module load cudatoolkit python cray-hdf5/1.14.3.7 cray-netcdf/4.9.2.1
 echo "Creating conda environment '$ENV_NAME' from nersc-python..."
 conda create -n "$ENV_NAME" --clone nersc-python -y
 
+echo "Installing Boost headers..."
+conda install -n "$ENV_NAME" -y -c conda-forge libboost-headers
+
 echo ""
 echo "Done. Environment '$ENV_NAME' is ready."
 echo "To activate, run: conda activate $ENV_NAME"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,16 +151,7 @@ endif()
 # too-old system Boost. Either way the download below would be triggered on
 # every fresh configure, so locate the headers directly instead.
 if(NOT Boost_FOUND)
-    # Discard the rejected location so find_path actually searches. Anything a
-    # too-old or incomplete install left behind must not win by default.
     unset(Boost_INCLUDE_DIR CACHE)
-
-    # An explicit Boost_INCLUDE_DIR first, then BOOST_ROOT/BOOSTROOT from the
-    # cache or the environment, then the prefix of the Python interpreter driving
-    # the build (conda envs keep Boost headers there). Hints outrank the system
-    # prefixes, so a current conda Boost beats an ancient /usr/include one.
-    # CMAKE_PREFIX_PATH and the standard system prefixes are searched by
-    # find_path itself.
     set(_boost_hints)
     if(_boost_user_include_dir)
         list(APPEND _boost_hints "${_boost_user_include_dir}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,24 +192,14 @@ if(NOT Boost_FOUND)
 
     set(_boost_version_string)
     if(Boost_INCLUDE_DIR AND EXISTS "${Boost_INCLUDE_DIR}/boost/version.hpp")
-        file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _boost_version_defines
-             REGEX "^#define[ \t]+BOOST_(LIB_)?VERSION[ \t]+")
-        foreach(_line ${_boost_version_defines})
-            if(_line MATCHES "^#define[ \t]+BOOST_VERSION[ \t]+([0-9]+)")
-                # BOOST_VERSION is encoded as major * 100000 + minor * 100 + patch.
-                math(EXPR _boost_major "${CMAKE_MATCH_1} / 100000")
-                math(EXPR _boost_minor "${CMAKE_MATCH_1} / 100 % 1000")
-                math(EXPR _boost_patch "${CMAKE_MATCH_1} % 100")
-                set(_boost_version_string "${_boost_major}.${_boost_minor}.${_boost_patch}")
-            endif()
-        endforeach()
-        if(NOT _boost_version_string)
-            # Fall back to the "1_76" style string if BOOST_VERSION is absent.
-            foreach(_line ${_boost_version_defines})
-                if(_line MATCHES "^#define[ \t]+BOOST_LIB_VERSION[ \t]+\"([0-9_]+)\"")
-                    string(REPLACE "_" "." _boost_version_string "${CMAKE_MATCH_1}")
-                endif()
-            endforeach()
+        file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _boost_version_line
+             REGEX "^#define[ \t]+BOOST_VERSION[ \t]+[0-9]+")
+        if(_boost_version_line MATCHES "BOOST_VERSION[ \t]+([0-9]+)")
+            # BOOST_VERSION is encoded as major * 100000 + minor * 100 + patch.
+            math(EXPR _boost_major "${CMAKE_MATCH_1} / 100000")
+            math(EXPR _boost_minor "${CMAKE_MATCH_1} / 100 % 1000")
+            math(EXPR _boost_patch "${CMAKE_MATCH_1} % 100")
+            set(_boost_version_string "${_boost_major}.${_boost_minor}.${_boost_patch}")
         endif()
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,14 +132,7 @@ else()
     set(USE_MPI FALSE)
 endif()
 
-# firm3d only uses header-only Boost (boost/format.hpp,
-# boost/math/tools/roots.hpp and boost/numeric/odeint.hpp), so a plain header
-# tree is all that is required -- no imported targets, no compiled components.
 set(BOOST_MINIMUM_VERSION 1.76.0)
-
-# A rejected find_package still caches Boost_INCLUDE_DIR pointing at whatever it
-# looked at, which would stop the fallback below from searching at all. Keep any
-# genuinely user-supplied value so it can be used as a hint instead.
 set(_boost_user_include_dir "${Boost_INCLUDE_DIR}")
 
 # Preferred route: an install that ships BoostConfig.cmake.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CMAKE_CUDA_COMPILER)
     set(CUDA_TARGETS  src/firm3dpp/cuda_kernel.cu src/firm3dpp/cuda_wrapper.cpp)
     message(STATUS "CUDA found. GPU bindings will be compiled.")
 else()
-    set(CUDA_TARGETS) 
+    set(CUDA_TARGETS)
     message(STATUS "CUDA not found. GPU bindings will be skipped.")
 endif()
 
@@ -132,7 +132,112 @@ else()
     set(USE_MPI FALSE)
 endif()
 
-find_package(Boost 1.76.0)
+# firm3d only uses header-only Boost (boost/format.hpp,
+# boost/math/tools/roots.hpp and boost/numeric/odeint.hpp), so a plain header
+# tree is all that is required -- no imported targets, no compiled components.
+set(BOOST_MINIMUM_VERSION 1.76.0)
+
+# A rejected find_package still caches Boost_INCLUDE_DIR pointing at whatever it
+# looked at, which would stop the fallback below from searching at all. Keep any
+# genuinely user-supplied value so it can be used as a hint instead.
+set(_boost_user_include_dir "${Boost_INCLUDE_DIR}")
+
+# Preferred route: an install that ships BoostConfig.cmake.
+find_package(Boost ${BOOST_MINIMUM_VERSION} QUIET)
+if(Boost_FOUND AND NOT Boost_INCLUDE_DIRS)
+    message(STATUS "find_package(Boost) provided no include dirs. Searching for headers instead.")
+    set(Boost_FOUND FALSE)
+elseif(Boost_FOUND)
+    message(STATUS "Boost located by find_package.")
+endif()
+
+# CMake deprecated FindBoost in 3.30 (CMP0167) and is retiring it, after which
+# the call above only succeeds in CONFIG mode against an install that ships
+# BoostConfig.cmake. Header-only installs (conda, pip, some system packages)
+# ship no such config, and where FindBoost still runs it may see nothing but a
+# too-old system Boost. Either way the download below would be triggered on
+# every fresh configure, so locate the headers directly instead.
+if(NOT Boost_FOUND)
+    # Discard the rejected location so find_path actually searches. Anything a
+    # too-old or incomplete install left behind must not win by default.
+    unset(Boost_INCLUDE_DIR CACHE)
+
+    # An explicit Boost_INCLUDE_DIR first, then BOOST_ROOT/BOOSTROOT from the
+    # cache or the environment, then the prefix of the Python interpreter driving
+    # the build (conda envs keep Boost headers there). Hints outrank the system
+    # prefixes, so a current conda Boost beats an ancient /usr/include one.
+    # CMAKE_PREFIX_PATH and the standard system prefixes are searched by
+    # find_path itself.
+    set(_boost_hints)
+    if(_boost_user_include_dir)
+        list(APPEND _boost_hints "${_boost_user_include_dir}")
+    endif()
+    foreach(_boost_root "${BOOST_ROOT}" "${BOOSTROOT}" "$ENV{BOOST_ROOT}"
+                        "$ENV{BOOSTROOT}" "$ENV{CONDA_PREFIX}")
+        if(_boost_root)
+            list(APPEND _boost_hints "${_boost_root}/include" "${_boost_root}")
+        endif()
+    endforeach()
+    if(Python_EXECUTABLE)
+        get_filename_component(_python_prefix "${Python_EXECUTABLE}" DIRECTORY)
+        get_filename_component(_python_prefix "${_python_prefix}" DIRECTORY)
+        list(APPEND _boost_hints "${_python_prefix}/include")
+    endif()
+
+    find_path(Boost_INCLUDE_DIR
+        NAMES boost/version.hpp
+        HINTS ${_boost_hints}
+        PATHS /usr/local/include /usr/include /opt/local/include /opt/homebrew/include
+        DOC "Directory holding the Boost header tree (the parent of boost/)")
+
+    set(_boost_version_string)
+    if(Boost_INCLUDE_DIR AND EXISTS "${Boost_INCLUDE_DIR}/boost/version.hpp")
+        file(STRINGS "${Boost_INCLUDE_DIR}/boost/version.hpp" _boost_version_defines
+             REGEX "^#define[ \t]+BOOST_(LIB_)?VERSION[ \t]+")
+        foreach(_line ${_boost_version_defines})
+            if(_line MATCHES "^#define[ \t]+BOOST_VERSION[ \t]+([0-9]+)")
+                # BOOST_VERSION is encoded as major * 100000 + minor * 100 + patch.
+                math(EXPR _boost_major "${CMAKE_MATCH_1} / 100000")
+                math(EXPR _boost_minor "${CMAKE_MATCH_1} / 100 % 1000")
+                math(EXPR _boost_patch "${CMAKE_MATCH_1} % 100")
+                set(_boost_version_string "${_boost_major}.${_boost_minor}.${_boost_patch}")
+            endif()
+        endforeach()
+        if(NOT _boost_version_string)
+            # Fall back to the "1_76" style string if BOOST_VERSION is absent.
+            foreach(_line ${_boost_version_defines})
+                if(_line MATCHES "^#define[ \t]+BOOST_LIB_VERSION[ \t]+\"([0-9_]+)\"")
+                    string(REPLACE "_" "." _boost_version_string "${CMAKE_MATCH_1}")
+                endif()
+            endforeach()
+        endif()
+    endif()
+
+    # Minimal installs sometimes ship a partial tree, so check that the headers
+    # firm3d actually includes are present before trusting the discovery.
+    set(_boost_missing_headers)
+    foreach(_header boost/format.hpp boost/math/tools/roots.hpp boost/numeric/odeint.hpp)
+        if(NOT EXISTS "${Boost_INCLUDE_DIR}/${_header}")
+            list(APPEND _boost_missing_headers "${_header}")
+        endif()
+    endforeach()
+
+    if(NOT Boost_INCLUDE_DIR OR NOT EXISTS "${Boost_INCLUDE_DIR}/boost/version.hpp")
+        message(STATUS "No Boost headers found in BOOST_ROOT, CMAKE_PREFIX_PATH, the Python prefix or the system paths.")
+    elseif(NOT _boost_version_string)
+        message(STATUS "Could not read a Boost version from ${Boost_INCLUDE_DIR}/boost/version.hpp.")
+    elseif(_boost_version_string VERSION_LESS ${BOOST_MINIMUM_VERSION})
+        message(STATUS "Boost ${_boost_version_string} in ${Boost_INCLUDE_DIR} is older than the required ${BOOST_MINIMUM_VERSION}.")
+    elseif(_boost_missing_headers)
+        message(STATUS "Boost headers in ${Boost_INCLUDE_DIR} are incomplete, missing ${_boost_missing_headers}.")
+    else()
+        set(Boost_FOUND TRUE)
+        set(Boost_VERSION_STRING ${_boost_version_string})
+        set(Boost_INCLUDE_DIRS ${Boost_INCLUDE_DIR})
+        message(STATUS "Boost located by header search (find_package found no usable package).")
+    endif()
+endif()
+
 if(Boost_FOUND)
     message(STATUS "Boost version is ${Boost_VERSION_STRING}")
     message(STATUS "Boost include dirs are ${Boost_INCLUDE_DIRS}")

--- a/install/perlmutter/install_firm3d_perlmutter.sh
+++ b/install/perlmutter/install_firm3d_perlmutter.sh
@@ -33,9 +33,6 @@ echo "Activating conda environment: $env_name"
 source activate "$env_name" || conda activate "$env_name"
 check_success "Failed to activate conda environment $env_name"
 
-# FIRM3D uses Boost header-only. nersc-python does not ship the headers and the
-# system Boost in /usr/include is older than the required 1.76, so without this
-# the build falls back to downloading boost, which fails on compute nodes.
 echo "Installing Boost headers..."
 conda install -y -c conda-forge libboost-headers
 check_success "Failed to install Boost headers"

--- a/install/perlmutter/install_firm3d_perlmutter.sh
+++ b/install/perlmutter/install_firm3d_perlmutter.sh
@@ -33,6 +33,13 @@ echo "Activating conda environment: $env_name"
 source activate "$env_name" || conda activate "$env_name"
 check_success "Failed to activate conda environment $env_name"
 
+# FIRM3D uses Boost header-only. nersc-python does not ship the headers and the
+# system Boost in /usr/include is older than the required 1.76, so without this
+# the build falls back to downloading boost, which fails on compute nodes.
+echo "Installing Boost headers..."
+conda install -y -c conda-forge libboost-headers
+check_success "Failed to install Boost headers"
+
 # FIRM3D Installation
 cd firm3d || { echo "Error: firm3d directory not found. Exiting."; exit 1; }
 export CI=True

--- a/install/perlmutter/install_simsopt_firm3d_perlmutter.sh
+++ b/install/perlmutter/install_simsopt_firm3d_perlmutter.sh
@@ -40,9 +40,6 @@ echo "Installing numpy (>=2.0,<2.4 for jax/simsopt + numba compatibility)..."
 pip install "numpy>=2.0,<2.4"
 check_success "Failed to install numpy"
 
-# firm3d uses Boost header-only. nersc-python does not ship the headers and the
-# system Boost in /usr/include is older than the required 1.76, so without this
-# the build falls back to downloading boost, which fails on compute nodes.
 echo "Installing Boost headers..."
 conda install -y -c conda-forge libboost-headers
 check_success "Failed to install Boost headers"

--- a/install/perlmutter/install_simsopt_firm3d_perlmutter.sh
+++ b/install/perlmutter/install_simsopt_firm3d_perlmutter.sh
@@ -40,6 +40,13 @@ echo "Installing numpy (>=2.0,<2.4 for jax/simsopt + numba compatibility)..."
 pip install "numpy>=2.0,<2.4"
 check_success "Failed to install numpy"
 
+# firm3d uses Boost header-only. nersc-python does not ship the headers and the
+# system Boost in /usr/include is older than the required 1.76, so without this
+# the build falls back to downloading boost, which fails on compute nodes.
+echo "Installing Boost headers..."
+conda install -y -c conda-forge libboost-headers
+check_success "Failed to install Boost headers"
+
 echo "Installing firm3d (with CUDA)..."
 cd firm3d || { echo "Error: firm3d directory not found. Exiting."; exit 1; }
 env CC=cc CXX=CC pip install -e ".[dev]"

--- a/src/firm3dpp/tracing.cpp
+++ b/src/firm3dpp/tracing.cpp
@@ -14,6 +14,9 @@
 #include <stdexcept>
 #include <iomanip>
 #include <boost/math/tools/roots.hpp>
+// Not redundant: newer Boost only pulls this in from roots.hpp when
+// BOOST_MATH_HAS_GPU_SUPPORT is undefined, and nvcc defines it.
+#include <boost/math/tools/toms748_solve.hpp>
 #include <boost/numeric/odeint.hpp>
 
 using std::shared_ptr;

--- a/src/firm3dpp/tracing.cpp
+++ b/src/firm3dpp/tracing.cpp
@@ -14,8 +14,6 @@
 #include <stdexcept>
 #include <iomanip>
 #include <boost/math/tools/roots.hpp>
-// Not redundant: newer Boost only pulls this in from roots.hpp when
-// BOOST_MATH_HAS_GPU_SUPPORT is undefined, and nvcc defines it.
 #include <boost/math/tools/toms748_solve.hpp>
 #include <boost/numeric/odeint.hpp>
 

--- a/src/firm3dpp/tracing_helpers.h
+++ b/src/firm3dpp/tracing_helpers.h
@@ -1,8 +1,6 @@
 #pragma once
 
 #include <boost/math/tools/roots.hpp>
-// Not redundant: newer Boost only pulls this in from roots.hpp when
-// BOOST_MATH_HAS_GPU_SUPPORT is undefined, and nvcc defines it.
 #include <boost/math/tools/toms748_solve.hpp>
 #include "tracing_helpers.h"
 #include <array>

--- a/src/firm3dpp/tracing_helpers.h
+++ b/src/firm3dpp/tracing_helpers.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <boost/math/tools/roots.hpp>
+// Not redundant: newer Boost only pulls this in from roots.hpp when
+// BOOST_MATH_HAS_GPU_SUPPORT is undefined, and nvcc defines it.
+#include <boost/math/tools/toms748_solve.hpp>
 #include "tracing_helpers.h"
 #include <array>
 #include <vector>


### PR DESCRIPTION
firm3d only uses header-only Boost — `boost/format.hpp`, `boost/math/tools/roots.hpp` and `boost/numeric/odeint.hpp` — but discovery went through `find_package` alone. CMake deprecated `FindBoost` in 3.30 (CMP0167) and is retiring it, leaving only CONFIG mode, which needs the install to provide `BoostConfig.cmake`. Many header-only installs, conda and pip in particular, provide none, so `find_package` fails and the build falls back to cloning boostorg via ExternalProject on every fresh configure.

On NERSC Perlmutter that blocks the build outright:

```
gmake[2]: *** [CMakeFiles/boost.dir/build.make:98: thirdparty/boost/src/boost-stamp/boost-download] Error 1
```

even though the conda env has perfectly good Boost 1.84 headers.

## What this does

Discovery now proceeds in three steps:

1. `find_package(Boost 1.76.0 QUIET)` — unchanged wherever it already works.
2. If that comes up empty, locate the headers directly: `find_path` for `boost/version.hpp` honouring `Boost_INCLUDE_DIR`, `BOOST_ROOT`/`BOOSTROOT` (cache and environment), `CONDA_PREFIX`, the Python interpreter prefix, `CMAKE_PREFIX_PATH` and the system prefixes. The version is parsed from `boost/version.hpp` and checked against the 1.76 minimum, then `Boost_FOUND`/`Boost_INCLUDE_DIRS` are set so the rest of the file is untouched.
3. Only if both fail do we download, so users with no Boost at all still build.

Rather than trusting `version.hpp` alone, discovery also requires the three headers firm3d actually includes to be present — some minimal installs ship a partial tree.

### One subtlety worth reviewing

A *rejected* `find_package` still caches `Boost_INCLUDE_DIR` pointing at whatever it looked at. On Perlmutter that is the too-old Boost 1.66 in `/usr/include`, which silently stopped `find_path` from searching at all. The rejected location is therefore cleared from the cache before searching, with any genuinely user-supplied value preserved as the highest-priority hint. This only reproduced on a real system — every local test passed without it.

## Testing

| Scenario | Result |
|---|---|
| Normal macOS configure, CMake 4.3.4 | `find_package` path unchanged; builds; 16 passed / 2 skipped |
| Header-only tree, no CMake config, `CMP0167=NEW` | Found by header search; zero download messages, no `boost` target; builds and passes tests against it |
| Hint routes: `BOOST_ROOT`, env `BOOST_ROOT`/`BOOSTROOT`, `CMAKE_PREFIX_PATH`, `Boost_INCLUDE_DIR` | All four resolve to the intended tree |
| Too-old (1.67), incomplete, and absent installs | All rejected with a specific reason; ExternalProject fallback still selected |
| **Perlmutter**, CMake 4.4.0, conda Boost 1.84, no config | Finds `$CONDA_PREFIX/include` at 1.84 instead of the system 1.66; no download; compiles all three headers |

Status messages name the path taken (`find_package` / header search with version and location / downloading) so build logs make the situation obvious.

Once this lands, the external `BoostConfig.cmake` shim on Perlmutter can be deleted and `build_variant.sh` simplified.

Independent of the submodule-removal PR; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make Boost discovery use compatible local header installations before falling back to downloading Boost.

New Features:
- Support discovering header-only Boost installations that do not provide a CMake package configuration, including conda and Python environments.
- Install Boost headers in the Perlmutter setup scripts.

Bug Fixes:
- Prevent valid newer Boost headers from being overlooked when a rejected package search caches an older system include path.
- Avoid unnecessary Boost downloads when a compatible local header-only installation is available.

Enhancements:
- Validate discovered Boost installations by checking the minimum version and the headers used by firm3d, while providing status messages for the selected discovery path.