### PR TITLE
Drop the unused thirdparty/boost submodule and the now-pointless --recursive

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,6 +13,3 @@
 [submodule "thirdparty/xtl"]
 	path = thirdparty/xtl
 	url = https://github.com/xtensor-stack/xtl.git
-[submodule "thirdparty/boost"]
-	path = thirdparty/boost
-	url = https://github.com/boostorg/boost.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(CMAKE_CUDA_COMPILER)
     set(CUDA_TARGETS  src/firm3dpp/cuda_kernel.cu src/firm3dpp/cuda_wrapper.cpp)
     message(STATUS "CUDA found. GPU bindings will be compiled.")
 else()
-    set(CUDA_TARGETS) 
+    set(CUDA_TARGETS)
     message(STATUS "CUDA not found. GPU bindings will be skipped.")
 endif()
 
@@ -56,7 +56,7 @@ if(GIT_FOUND AND EXISTS "${PROJECT_SOURCE_DIR}/.git")
     option(GIT_SUBMODULE "Check submodules during build" ON)
     if(GIT_SUBMODULE)
         message(STATUS "Submodule update")
-        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init --recursive
+        execute_process(COMMAND ${GIT_EXECUTABLE} submodule update --init
                         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
                         RESULT_VARIABLE GIT_SUBMOD_RESULT)
         if(NOT GIT_SUBMOD_RESULT EQUAL "0")


### PR DESCRIPTION
The `thirdparty/boost` submodule was added as an experiment in January 2025 and never wired into the build. Nothing reads it.

- 30524bf6 "Experimenting with re-introducing boost." added *only* the 3-line `.gitmodules` entry — no CMakeLists change.
- 38b86ec3 "Got rid of gsl dependencies." added the gitlink as a drive-by inside an otherwise unrelated GSL/tracing commit.

The only `thirdparty/boost` path in `CMakeLists.txt` is `${CMAKE_CURRENT_BINARY_DIR}/thirdparty/boost` — the *build*-directory destination for the ExternalProject fallback, which clones boost from GitHub and never looks at the submodule.

## It is not free

`CMakeLists.txt` updates submodules on every fresh configure, and the pinned boost commit declares **167 nested submodules** that the build then ignores. Measured on a fresh clone, running exactly what CMake runs:

| | before | after |
|---|---|---|
| submodule update | **4 min 31 s** | **17 s** |
| `.git` after | **2.2 GB** | **684 MB** |
| submodules pulled | 6 + 167 nested | 5 |

Of the remaining 684 MB, 529 MB is firm3d's own history; the five real submodules account for 155 MB of objects and 28 MB of checked-out headers.

`docs/installation.rst` documents a plain `git clone` and the install scripts do not touch submodules, so this cost lands on the user at first configure. The Perlmutter GPU CI runs `pip install --no-build-isolation -e .` on a compute node under a 30-minute debug-queue limit, so it pays it there too.

## `--recursive` goes too

Boost was the only reason to recurse. None of xtensor, xtensor-python, xsimd, xtl or eigen declares nested submodules, so the flag was a no-op once boost was gone. Verified on a fresh clone that plain `--init` checks out all five and produces every header the build includes:

```
thirdparty/xtensor/include/xtensor/xnoalias.hpp                OK
thirdparty/xtensor-python/include/xtensor-python/pyarray.hpp   OK
thirdparty/xsimd/include/xsimd/xsimd.hpp                       OK
thirdparty/xtl/include/xtl/xtype_traits.hpp                    OK
thirdparty/eigen/Eigen/Dense                                   OK
```

with no submodule left uninitialized. Dropping it also means a dependency bump can no longer pull in a nested submodule unnoticed.

## Notes

- Configure with `GIT_SUBMODULE` at its default ON exits 0, no boost is cloned, and build → import → 16 passed / 2 skipped still works.
- Existing clones keep a stale `.git/modules/thirdparty/boost`; it is inert and reclaimable with `rm -rf`.

Composes cleanly with the Boost-detection PR in either merge order (verified — identical resulting tree, and the combined state builds and passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)