### PR TITLE
Evaluate a superposition of Alfvén harmonics in one pass

### DIFF
--- a/examples/tracing_with_AE/README.txt
+++ b/examples/tracing_with_AE/README.txt
@@ -1,15 +1,15 @@
 This example demonstrates the selection of an eigenmode from AE3D and postprocessing of the mode
-to perform guiding center tracing. The Wistell-A equilibrium is used. 
+to perform guiding center tracing. The Wistell-A equilibrium is used.
 
 Stellgap: https://github.com/ORNL-Fusion/Stellgap
 AE3D: https://github.com/ORNL-Fusion/AE3D
 
 First, using the notebook ChooseAE.ipynb, the spectrum computed from AE3D and stellgap is visualized,
-so that the position of global eigenmodes can be identified with respect to the continuum gap structure. 
+so that the position of global eigenmodes can be identified with respect to the continuum gap structure.
 The eigenmode is then saved in a file, ae.npy. The data obtained from stellgap and AE3D are provided
-in the directories stellgap_output and ae3d_output, respectively. 
+in the directories stellgap_output and ae3d_output, respectively.
 
-Then, the script tracing_with_AE.py is used to perform guiding center tracing using a fusion birth 
-distribution function. The loss fraction is plotted as a function of time. 
+Then, the script tracing_with_AE.py is used to perform guiding center tracing using a fusion birth
+distribution function. The loss fraction is plotted as a function of time.
 
-On perlmutter (07.05.25), the wallclock time is about 21 minutes using the included slurm script.
+On perlmutter (08.15.26), the wallclock time is about 4 minutes using the included slurm script.

--- a/examples/tracing_with_FAR3D_IVP/README.txt
+++ b/examples/tracing_with_FAR3D_IVP/README.txt
@@ -4,4 +4,6 @@ Running FAR3D produces `phi_0000` and `temp_grwth_omega` files. `phi_0000` conta
 
 `tracing_with_FAR3D_AE.py` reads the numpy file and provided VMEC equilibrium file in Boozer coordinates (boozmn.nc) and performs the perturbed particle tracing for an fusion-born alpha particle population.
 
+On perlmutter (08.17.26), the wallclock time is about 8 minutes using the included slurm script.
+
 FAR3D: J. Varela, *et al.* Stability optimization of energetic particle driven modes in nuclear fusion devices: the FAR3d gyrofluid code. *Front. Phys.* 12:1422411. 2024. doi: 10.3389/fphy.2024.1422411.

--- a/examples/tracing_with_FAR3D_IVP/tracing_with_FAR3D_AE.py
+++ b/examples/tracing_with_FAR3D_IVP/tracing_with_FAR3D_AE.py
@@ -23,8 +23,8 @@ from firm3d.util.constants import (
 from firm3d.util.functions import in_github_actions, proc0_print, setup_logging
 from firm3d.util.mpi import comm_size, comm_world, verbose
 
-resolution = 5  # Resolution for field interpolation
-nParticles = 5  # Number of particles to trace
+resolution = 10 if in_github_actions else 48  # Resolution for field interpolation
+nParticles = 50 if in_github_actions else 5000  # Number of particles to trace
 reltol = 1e-4 if in_github_actions else 1e-8  # Relative tolerance for the ODE solver
 abstol = 1e-4 if in_github_actions else 1e-8  # Absolute tolerance for the ODE solver
 order = 3  # Order for radial interpolation

--- a/src/firm3d/field/boozermagneticfield.py
+++ b/src/firm3d/field/boozermagneticfield.py
@@ -3839,11 +3839,9 @@ class ShearAlfvenWavesSuperposition(
 ):
     r"""
     Class representing a superposition of multiple Shear Alfvén Waves (SAWs).
-
-    This class models the superposition of multiple Shear Alfvén waves,
-    combining their scalar
-    potential `Phi`, vector potential `alpha`, and their respective derivatives
-    to represent a more
+    This class models the superposition of :class:`ShearAlfvenHarmonic` instances
+    in the same equilibrium field, combining their scalar potential `Phi`,
+    vector potential `alpha`, and their respective derivatives to represent a more
     complex wave structure in the equilibrium field `B0`.
 
     The superposition of waves is initialized with a base wave, which defines
@@ -3851,11 +3849,6 @@ class ShearAlfvenWavesSuperposition(
     equilibrium field `B0` for all subsequent waves added to the superposition.
     All added waves
     must have the same `B0` field.
-
-    The waves must be :class:`ShearAlfvenHarmonic` instances: the superposition
-    evaluates them together in a single pass over the points rather than one
-    wave at a time, which is what makes tracing cost independent of the number
-    of harmonics. Adding any other kind of wave raises.
 
     See Paul et al., JPP (2023; 89(5):905890515.
     doi:10.1017/S0022377823001095) for more details.

--- a/src/firm3d/field/boozermagneticfield.py
+++ b/src/firm3d/field/boozermagneticfield.py
@@ -3852,14 +3852,19 @@ class ShearAlfvenWavesSuperposition(
     All added waves
     must have the same `B0` field.
 
+    The waves must be :class:`ShearAlfvenHarmonic` instances: the superposition
+    evaluates them together in a single pass over the points rather than one
+    wave at a time, which is what makes tracing cost independent of the number
+    of harmonics. Adding any other kind of wave raises.
+
     See Paul et al., JPP (2023; 89(5):905890515.
     doi:10.1017/S0022377823001095) for more details.
 
     Parameters
     ----------
-    SAWs : list of ShearAlfvenWave
-        A list of ShearAlfvenWave objects to be superposed. The first wave in
-        the list is used
+    SAWs : list of ShearAlfvenHarmonic
+        A list of ShearAlfvenHarmonic objects to be superposed. The first wave
+        in the list is used
         as the base wave and defines the reference `B0` field for the
         superposition. All other
         waves in the list must have the same `B0`.
@@ -3869,6 +3874,8 @@ class ShearAlfvenWavesSuperposition(
     TypeError
         If `SAWs` is not a list of `ShearAlfvenWave` objects.
         If the base wave is not provided or if the waves have different `B0` fields.
+    ValueError
+        If any wave is not a `ShearAlfvenHarmonic`.
 
     Examples
     --------

--- a/src/firm3dpp/shearalfvenwave.h
+++ b/src/firm3dpp/shearalfvenwave.h
@@ -677,6 +677,7 @@ private:
         dGdpsi = data_dGds(i, 0) / psi0;
         dIdpsi = data_dIds(i, 0) / psi0;
       }
+      const double denom = G + iota * I;
 
       double sum_Phi = 0., sum_dPhidpsi = 0., sum_dPhidtheta = 0.,
              sum_dPhidzeta = 0., sum_Phidot = 0., sum_alpha = 0.,
@@ -684,16 +685,13 @@ private:
              sum_dalphadzeta = 0.;
 
       for (const auto* h : harmonics) {
-        double alpha_fac, d_alpha_fac_dpsi;
+        const double alpha_fac =
+            (iota * h->Phim - h->Phin) / (h->omega * denom);
+        double d_alpha_fac_dpsi = (diotadpsi * h->Phim) / (h->omega * denom);
         if (!vacuum) {
-          const double denom = G + iota * I;
-          alpha_fac = (iota * h->Phim - h->Phin) / (h->omega * denom);
-          d_alpha_fac_dpsi = (diotadpsi * h->Phim) / (h->omega * denom) -
-                             alpha_fac / denom *
-                                 (dGdpsi + diotadpsi * I + iota * dIdpsi);
-        } else {
-          alpha_fac = (iota * h->Phim - h->Phin) / (h->omega * G);
-          d_alpha_fac_dpsi = diotadpsi * h->Phim / (h->omega * G);
+          // Only away from vacuum do G and I themselves vary with psi.
+          d_alpha_fac_dpsi -=
+              alpha_fac / denom * (dGdpsi + diotadpsi * I + iota * dIdpsi);
         }
 
         const double arg =

--- a/src/firm3dpp/shearalfvenwave.h
+++ b/src/firm3dpp/shearalfvenwave.h
@@ -558,8 +558,7 @@ public:
     if (!harmonic) {
       throw std::invalid_argument(
         "A ShearAlfvenWavesSuperposition may only contain "
-        "ShearAlfvenHarmonics: it evaluates them together in a single pass "
-        "rather than wave by wave."
+        "ShearAlfvenHarmonics."
       );
     }
     waves.push_back(wave);
@@ -604,8 +603,6 @@ public:
     if (index >= waves.size()) {
       throw std::out_of_range("Wave index out of range");
     }
-    // The harmonics are never given the points individually, so bring this one
-    // up to date before it is handed out to be queried on its own.
     if (points.size() > 0) {
       Array2 p = points;
       waves[index]->set_points(p);
@@ -618,17 +615,6 @@ public:
   }
 
 private:
-  /* All harmonics share one B0 and are evaluated together in a single pass.
-   *
-   * Giving the points to each wave in turn instead, and summing a per-wave
-   * array for every quantity read, costs far more than the arithmetic: each
-   * wave re-sets B0, re-reads its flux functions, builds xtensor temporaries
-   * and allocates its own ten output arrays, all to produce one value per
-   * quantity. A tracing RHS evaluates a single point per step, so that
-   * per-wave cost dominated and grew linearly with the number of harmonics.
-   *
-   * Harmonics are accumulated in the order they were added.
-   */
   std::vector<ShearAlfvenHarmonic*> harmonics;  // non-owning; parallel to waves
   Array2 total_Phi, total_dPhidpsi, total_dPhidtheta, total_dPhidzeta,
       total_Phidot, total_alpha, total_alphadot, total_dalphadpsi,
@@ -725,9 +711,6 @@ private:
       total_dPhidtheta(i, 0) = sum_dPhidtheta;
       total_dPhidzeta(i, 0) = sum_dPhidzeta;
       total_Phidot(i, 0) = sum_Phidot;
-      // alpha and dalphadzeta are only defined when the field retains K; the
-      // per-wave path leaves them untouched in the vacuum case, so report
-      // zero rather than a stale value.
       total_alpha(i, 0) = sum_alpha;
       total_dalphadzeta(i, 0) = sum_dalphadzeta;
       total_alphadot(i, 0) = sum_alphadot;

--- a/src/firm3dpp/shearalfvenwave.h
+++ b/src/firm3dpp/shearalfvenwave.h
@@ -639,7 +639,7 @@ private:
   }
 
   void evaluate_harmonics(Array2& p) {
-    const bool retains_K = (B0->field_type == "nok" || B0->field_type == "");
+    const bool vacuum = (B0->field_type == "vac");
     const double psi0 = B0->psi0;
 
     // Flux functions are read once here rather than once per harmonic.
@@ -647,9 +647,9 @@ private:
     auto& data_G = B0->G_ref();
     auto& data_diotads = B0->diotads_ref();
     Array2 empty;
-    auto& data_I = retains_K ? B0->I_ref() : empty;
-    auto& data_dGds = retains_K ? B0->dGds_ref() : empty;
-    auto& data_dIds = retains_K ? B0->dIds_ref() : empty;
+    auto& data_I = vacuum ? empty : B0->I_ref();
+    auto& data_dGds = vacuum ? empty : B0->dGds_ref();
+    auto& data_dIds = vacuum ? empty : B0->dIds_ref();
 
     total_Phi.resize({npoints, 1});
     total_dPhidpsi.resize({npoints, 1});
@@ -672,7 +672,7 @@ private:
       const double G = data_G(i, 0);
       const double diotadpsi = data_diotads(i, 0) / psi0;
       double I = 0., dGdpsi = 0., dIdpsi = 0.;
-      if (retains_K) {
+      if (!vacuum) {
         I = data_I(i, 0);
         dGdpsi = data_dGds(i, 0) / psi0;
         dIdpsi = data_dIds(i, 0) / psi0;
@@ -685,7 +685,7 @@ private:
 
       for (const auto* h : harmonics) {
         double alpha_fac, d_alpha_fac_dpsi;
-        if (retains_K) {
+        if (!vacuum) {
           const double denom = G + iota * I;
           alpha_fac = (iota * h->Phim - h->Phin) / (h->omega * denom);
           d_alpha_fac_dpsi = (diotadpsi * h->Phim) / (h->omega * denom) -

--- a/src/firm3dpp/shearalfvenwave.h
+++ b/src/firm3dpp/shearalfvenwave.h
@@ -639,7 +639,6 @@ private:
   }
 
   void evaluate_harmonics(Array2& p) {
-    // retains_K mirrors the branch in ShearAlfvenHarmonic::set_points
     const bool retains_K = (B0->field_type == "nok" || B0->field_type == "");
     const double psi0 = B0->psi0;
 
@@ -715,10 +714,8 @@ private:
         sum_Phidot += Phidot;
         sum_dPhidtheta += dPhidtheta;
         sum_dPhidzeta += dPhidzeta;
-        if (retains_K) {
-          sum_alpha += -Phi * alpha_fac;
-          sum_dalphadzeta += -dPhidzeta * alpha_fac;
-        }
+        sum_alpha += -Phi * alpha_fac;
+        sum_dalphadzeta += -dPhidzeta * alpha_fac;
         sum_alphadot += -Phidot * alpha_fac;
         sum_dalphadpsi += -dPhidpsi * alpha_fac - Phi * d_alpha_fac_dpsi;
         sum_dalphadtheta += -dPhidtheta * alpha_fac;

--- a/src/firm3dpp/shearalfvenwave.h
+++ b/src/firm3dpp/shearalfvenwave.h
@@ -544,6 +544,9 @@ public:
   *  The superposition evaluates its harmonics together in a single pass
   *  (see evaluate_harmonics), which is why only harmonics are accepted.
   *
+  *  If points have already been set, the stored quantities are re-evaluated
+  *  so that they describe the superposition including the new harmonic.
+  *
   * @param wave Shared pointer to a ShearAlfvenHarmonic to be added.
   * @throws std::invalid_argument if the wave's `B0` field does not
   * match the superposition's `B0`, or if it is not a ShearAlfvenHarmonic.
@@ -563,6 +566,7 @@ public:
     }
     waves.push_back(wave);
     harmonics.push_back(harmonic);
+    reevaluate();
   }
 
   /**
@@ -619,6 +623,20 @@ private:
   Array2 total_Phi, total_dPhidpsi, total_dPhidtheta, total_dPhidzeta,
       total_Phidot, total_alpha, total_alphadot, total_dalphadpsi,
       total_dalphadtheta, total_dalphadzeta;
+
+  /* Re-runs the evaluation at the points already stored, if there are any.
+   */
+  void reevaluate() {
+    if (points.size() == 0) {
+      return;
+    }
+    // set_points copies into `points`, so hand it a copy rather than alias it.
+    Array2 p = points;
+    // B0 is shared with the harmonics and may have been moved since, so put it
+    // back on these points before reading its flux functions.
+    ShearAlfvenWave::set_points(p);
+    evaluate_harmonics(p);
+  }
 
   void evaluate_harmonics(Array2& p) {
     // retains_K mirrors the branch in ShearAlfvenHarmonic::set_points

--- a/src/firm3dpp/shearalfvenwave.h
+++ b/src/firm3dpp/shearalfvenwave.h
@@ -553,6 +553,7 @@ public:
       );
     }
     waves.push_back(wave);
+    refresh_fusion();
   }
 
   /**
@@ -584,9 +585,13 @@ public:
   *          and time (s, theta, zeta, time).
   */
   void set_points(Array2& p) override {
-    ShearAlfvenWave::set_points(p);
-    for (const auto& wave : waves) {
-      wave->set_points(p);  // Propagate points to each wave
+    ShearAlfvenWave::set_points(p);  // stores the points and sets B0 once
+    if (fused) {
+      evaluate_fused(p);
+    } else {
+      for (const auto& wave : waves) {
+        wave->set_points(p);  // Propagate points to each wave
+      }
     }
   }
 
@@ -594,15 +599,161 @@ public:
     if (index >= waves.size()) {
       throw std::out_of_range("Wave index out of range");
     }
+    // The fused path never hands the points to the individual waves, so bring
+    // this one up to date before it is handed out to be queried on its own.
+    if (fused && points.size() > 0) {
+      Array2 p = points;
+      waves[index]->set_points(p);
+    }
     return waves[index];
   }
 
   size_t size() const {
     return waves.size();
   }
-  
+
+private:
+  /* Fused evaluation of a superposition of ShearAlfvenHarmonics.
+   *
+   * All waves share one B0 (add_wave enforces it), so when every wave is a
+   * ShearAlfvenHarmonic the whole superposition can be evaluated in a single
+   * pass. The generic path below instead calls set_points on every wave --
+   * each of which re-sets B0 and re-reads its flux functions, allocates ten
+   * output arrays and builds xtensor temporaries -- and then sums N per-wave
+   * arrays again for each quantity read. A tracing RHS evaluates one point at
+   * a time, so that per-wave framework cost, not the arithmetic, dominates.
+   *
+   * Harmonics are accumulated in the order they appear in `waves`, matching
+   * the summation order of the generic path.
+   */
+  std::vector<ShearAlfvenHarmonic*> harmonics;  // non-owning; valid iff fused
+  bool fused = false;
+  Array2 fused_Phi, fused_dPhidpsi, fused_dPhidtheta, fused_dPhidzeta,
+      fused_Phidot, fused_alpha, fused_alphadot, fused_dalphadpsi,
+      fused_dalphadtheta, fused_dalphadzeta;
+
+  void refresh_fusion() {
+    harmonics.clear();
+    for (const auto& wave : waves) {
+      auto* h = dynamic_cast<ShearAlfvenHarmonic*>(wave.get());
+      if (!h) {  // e.g. a nested superposition or an interpolated wave
+        harmonics.clear();
+        fused = false;
+        return;
+      }
+      harmonics.push_back(h);
+    }
+    fused = !harmonics.empty();
+  }
+
+  void evaluate_fused(Array2& p) {
+    // retains_K mirrors the branch in ShearAlfvenHarmonic::set_points
+    const bool retains_K = (B0->field_type == "nok" || B0->field_type == "");
+    const double psi0 = B0->psi0;
+
+    // Flux functions are read once here rather than once per harmonic.
+    auto& data_iota = B0->iota_ref();
+    auto& data_G = B0->G_ref();
+    auto& data_diotads = B0->diotads_ref();
+    Array2 empty;
+    auto& data_I = retains_K ? B0->I_ref() : empty;
+    auto& data_dGds = retains_K ? B0->dGds_ref() : empty;
+    auto& data_dIds = retains_K ? B0->dIds_ref() : empty;
+
+    fused_Phi.resize({npoints, 1});
+    fused_dPhidpsi.resize({npoints, 1});
+    fused_dPhidtheta.resize({npoints, 1});
+    fused_dPhidzeta.resize({npoints, 1});
+    fused_Phidot.resize({npoints, 1});
+    fused_alpha.resize({npoints, 1});
+    fused_alphadot.resize({npoints, 1});
+    fused_dalphadpsi.resize({npoints, 1});
+    fused_dalphadtheta.resize({npoints, 1});
+    fused_dalphadzeta.resize({npoints, 1});
+
+    for (long i = 0; i < npoints; ++i) {
+      const double s = p(i, 0);
+      const double theta = p(i, 1);
+      const double zeta = p(i, 2);
+      const double time = p(i, 3);
+
+      const double iota = data_iota(i, 0);
+      const double G = data_G(i, 0);
+      const double diotadpsi = data_diotads(i, 0) / psi0;
+      double I = 0., dGdpsi = 0., dIdpsi = 0.;
+      if (retains_K) {
+        I = data_I(i, 0);
+        dGdpsi = data_dGds(i, 0) / psi0;
+        dIdpsi = data_dIds(i, 0) / psi0;
+      }
+
+      double sum_Phi = 0., sum_dPhidpsi = 0., sum_dPhidtheta = 0.,
+             sum_dPhidzeta = 0., sum_Phidot = 0., sum_alpha = 0.,
+             sum_alphadot = 0., sum_dalphadpsi = 0., sum_dalphadtheta = 0.,
+             sum_dalphadzeta = 0.;
+
+      for (const auto* h : harmonics) {
+        double alpha_fac, d_alpha_fac_dpsi;
+        if (retains_K) {
+          const double denom = G + iota * I;
+          alpha_fac = (iota * h->Phim - h->Phin) / (h->omega * denom);
+          d_alpha_fac_dpsi = (diotadpsi * h->Phim) / (h->omega * denom) -
+                             alpha_fac / denom *
+                                 (dGdpsi + diotadpsi * I + iota * dIdpsi);
+        } else {
+          alpha_fac = (iota * h->Phim - h->Phin) / (h->omega * G);
+          d_alpha_fac_dpsi = diotadpsi * h->Phim / (h->omega * G);
+        }
+
+        const double arg =
+            h->Phim * theta - h->Phin * zeta + h->omega * time + h->phase;
+        const double data_cos = cos(arg);
+        const double data_sin = sin(arg);
+        const double phihat_s = h->phihat(s);
+        const double dphihatdpsi = h->phihat.derivative(s) / psi0;
+
+        const double Phi = phihat_s * data_sin;
+        const double dPhidpsi = dphihatdpsi * data_sin;
+        const double Phidot = phihat_s * data_cos * h->omega;
+        const double dPhidtheta = Phidot * (h->Phim / h->omega);
+        const double dPhidzeta = -Phidot * (h->Phin / h->omega);
+
+        sum_Phi += Phi;
+        sum_dPhidpsi += dPhidpsi;
+        sum_Phidot += Phidot;
+        sum_dPhidtheta += dPhidtheta;
+        sum_dPhidzeta += dPhidzeta;
+        if (retains_K) {
+          sum_alpha += -Phi * alpha_fac;
+          sum_dalphadzeta += -dPhidzeta * alpha_fac;
+        }
+        sum_alphadot += -Phidot * alpha_fac;
+        sum_dalphadpsi += -dPhidpsi * alpha_fac - Phi * d_alpha_fac_dpsi;
+        sum_dalphadtheta += -dPhidtheta * alpha_fac;
+      }
+
+      fused_Phi(i, 0) = sum_Phi;
+      fused_dPhidpsi(i, 0) = sum_dPhidpsi;
+      fused_dPhidtheta(i, 0) = sum_dPhidtheta;
+      fused_dPhidzeta(i, 0) = sum_dPhidzeta;
+      fused_Phidot(i, 0) = sum_Phidot;
+      // alpha and dalphadzeta are only defined when the field retains K; the
+      // per-wave path leaves them untouched in the vacuum case, so report
+      // zero rather than a stale value.
+      fused_alpha(i, 0) = sum_alpha;
+      fused_dalphadzeta(i, 0) = sum_dalphadzeta;
+      fused_alphadot(i, 0) = sum_alphadot;
+      fused_dalphadpsi(i, 0) = sum_dalphadpsi;
+      fused_dalphadtheta(i, 0) = sum_dalphadtheta;
+    }
+  }
+
 protected:
   void _Phi_impl(Array2& Phi) override {
+    if (fused) {
+      Phi = fused_Phi;
+      return;
+    }
     Phi.fill(0.0);
     for (const auto& wave : waves) {
       Phi += wave->Phi();
@@ -610,6 +761,10 @@ protected:
   }
 
   void _dPhidpsi_impl(Array2& dPhidpsi) override {
+    if (fused) {
+      dPhidpsi = fused_dPhidpsi;
+      return;
+    }
     dPhidpsi.fill(0.0);
     for (const auto& wave : waves) {
       dPhidpsi += wave->dPhidpsi();
@@ -617,6 +772,10 @@ protected:
   }
 
   void _dPhidtheta_impl(Array2& dPhidtheta) override {
+    if (fused) {
+      dPhidtheta = fused_dPhidtheta;
+      return;
+    }
     dPhidtheta.fill(0.0);
     for (const auto& wave : waves) {
       dPhidtheta += wave->dPhidtheta();
@@ -624,6 +783,10 @@ protected:
   }
 
   void _dPhidzeta_impl(Array2& dPhidzeta) override {
+    if (fused) {
+      dPhidzeta = fused_dPhidzeta;
+      return;
+    }
     dPhidzeta.fill(0.0);
     for (const auto& wave : waves) {
       dPhidzeta += wave->dPhidzeta();
@@ -631,6 +794,10 @@ protected:
   }
 
   void _Phidot_impl(Array2& Phidot) override {
+    if (fused) {
+      Phidot = fused_Phidot;
+      return;
+    }
     Phidot.fill(0.0);
       for (const auto& wave : waves) {
       Phidot += wave->Phidot();
@@ -638,6 +805,10 @@ protected:
   }
 
   void _alpha_impl(Array2& alpha) override {
+    if (fused) {
+      alpha = fused_alpha;
+      return;
+    }
     alpha.fill(0.0);
     for (const auto& wave : waves) {
       alpha += wave->alpha();
@@ -645,6 +816,10 @@ protected:
   }
 
   void _dalphadpsi_impl(Array2& dalphadpsi) override {
+    if (fused) {
+      dalphadpsi = fused_dalphadpsi;
+      return;
+    }
     dalphadpsi.fill(0.0);
     for (const auto& wave : waves) {
       dalphadpsi += wave->dalphadpsi();
@@ -652,6 +827,10 @@ protected:
   }
 
   void _dalphadtheta_impl(Array2& dalphadtheta) override {
+    if (fused) {
+      dalphadtheta = fused_dalphadtheta;
+      return;
+    }
     dalphadtheta.fill(0.0);
     for (const auto& wave : waves) {
       dalphadtheta += wave->dalphadtheta();
@@ -659,6 +838,10 @@ protected:
   }
 
   void _dalphadzeta_impl(Array2& dalphadzeta) override {
+    if (fused) {
+      dalphadzeta = fused_dalphadzeta;
+      return;
+    }
     dalphadzeta.fill(0.0);
     for (const auto& wave : waves) {
       dalphadzeta += wave->dalphadzeta();
@@ -666,6 +849,10 @@ protected:
   }
 
   void _alphadot_impl(Array2& alphadot) override {
+    if (fused) {
+      alphadot = fused_alphadot;
+      return;
+    }
     alphadot.fill(0.0);
     for (const auto& wave : waves) {
       alphadot += wave->alphadot();

--- a/src/firm3dpp/shearalfvenwave.h
+++ b/src/firm3dpp/shearalfvenwave.h
@@ -537,14 +537,16 @@ public:
   std::vector<std::shared_ptr<ShearAlfvenWave>> waves;
 
   /**
-  * @brief Adds a new wave to the superposition.
+  * @brief Adds a new harmonic to the superposition.
   *
-  *  Adds a new wave to the superposition after verifying
-  *  that it has the same equilibrium magnetic field `B0`.
+  *  Adds a new wave to the superposition after verifying that it is a
+  *  ShearAlfvenHarmonic and has the same equilibrium magnetic field `B0`.
+  *  The superposition evaluates its harmonics together in a single pass
+  *  (see evaluate_harmonics), which is why only harmonics are accepted.
   *
-  * @param wave Shared pointer to a ShearAlfvenWave object to be added.
+  * @param wave Shared pointer to a ShearAlfvenHarmonic to be added.
   * @throws std::invalid_argument if the wave's `B0` field does not
-  * match the superposition's `B0`.
+  * match the superposition's `B0`, or if it is not a ShearAlfvenHarmonic.
   */
   void add_wave(const std::shared_ptr<ShearAlfvenWave>& wave) {
     if (wave->get_B0() != this->B0) {
@@ -552,8 +554,16 @@ public:
         "The wave's B0 field does not match the superposition's B0 field."
       );
     }
+    auto* harmonic = dynamic_cast<ShearAlfvenHarmonic*>(wave.get());
+    if (!harmonic) {
+      throw std::invalid_argument(
+        "A ShearAlfvenWavesSuperposition may only contain "
+        "ShearAlfvenHarmonics: it evaluates them together in a single pass "
+        "rather than wave by wave."
+      );
+    }
     waves.push_back(wave);
-    refresh_fusion();
+    harmonics.push_back(harmonic);
   }
 
   /**
@@ -579,29 +589,24 @@ public:
   /**
   * @brief Sets the points (s, theta, zeta, time)
   *
-  * Sets the points for the superposition and propagates them to all waves.
+  * Sets the points for the superposition and evaluates every harmonic at
+  * them in a single pass.
   *
   * @param p A tensor representing the points in Boozer coordinates
   *          and time (s, theta, zeta, time).
   */
   void set_points(Array2& p) override {
     ShearAlfvenWave::set_points(p);  // stores the points and sets B0 once
-    if (fused) {
-      evaluate_fused(p);
-    } else {
-      for (const auto& wave : waves) {
-        wave->set_points(p);  // Propagate points to each wave
-      }
-    }
+    evaluate_harmonics(p);
   }
 
   std::shared_ptr<ShearAlfvenWave> get_wave(size_t index) const {
     if (index >= waves.size()) {
       throw std::out_of_range("Wave index out of range");
     }
-    // The fused path never hands the points to the individual waves, so bring
-    // this one up to date before it is handed out to be queried on its own.
-    if (fused && points.size() > 0) {
+    // The harmonics are never given the points individually, so bring this one
+    // up to date before it is handed out to be queried on its own.
+    if (points.size() > 0) {
       Array2 p = points;
       waves[index]->set_points(p);
     }
@@ -613,40 +618,23 @@ public:
   }
 
 private:
-  /* Fused evaluation of a superposition of ShearAlfvenHarmonics.
+  /* All harmonics share one B0 and are evaluated together in a single pass.
    *
-   * All waves share one B0 (add_wave enforces it), so when every wave is a
-   * ShearAlfvenHarmonic the whole superposition can be evaluated in a single
-   * pass. The generic path below instead calls set_points on every wave --
-   * each of which re-sets B0 and re-reads its flux functions, allocates ten
-   * output arrays and builds xtensor temporaries -- and then sums N per-wave
-   * arrays again for each quantity read. A tracing RHS evaluates one point at
-   * a time, so that per-wave framework cost, not the arithmetic, dominates.
+   * Giving the points to each wave in turn instead, and summing a per-wave
+   * array for every quantity read, costs far more than the arithmetic: each
+   * wave re-sets B0, re-reads its flux functions, builds xtensor temporaries
+   * and allocates its own ten output arrays, all to produce one value per
+   * quantity. A tracing RHS evaluates a single point per step, so that
+   * per-wave cost dominated and grew linearly with the number of harmonics.
    *
-   * Harmonics are accumulated in the order they appear in `waves`, matching
-   * the summation order of the generic path.
+   * Harmonics are accumulated in the order they were added.
    */
-  std::vector<ShearAlfvenHarmonic*> harmonics;  // non-owning; valid iff fused
-  bool fused = false;
-  Array2 fused_Phi, fused_dPhidpsi, fused_dPhidtheta, fused_dPhidzeta,
-      fused_Phidot, fused_alpha, fused_alphadot, fused_dalphadpsi,
-      fused_dalphadtheta, fused_dalphadzeta;
+  std::vector<ShearAlfvenHarmonic*> harmonics;  // non-owning; parallel to waves
+  Array2 total_Phi, total_dPhidpsi, total_dPhidtheta, total_dPhidzeta,
+      total_Phidot, total_alpha, total_alphadot, total_dalphadpsi,
+      total_dalphadtheta, total_dalphadzeta;
 
-  void refresh_fusion() {
-    harmonics.clear();
-    for (const auto& wave : waves) {
-      auto* h = dynamic_cast<ShearAlfvenHarmonic*>(wave.get());
-      if (!h) {  // e.g. a nested superposition or an interpolated wave
-        harmonics.clear();
-        fused = false;
-        return;
-      }
-      harmonics.push_back(h);
-    }
-    fused = !harmonics.empty();
-  }
-
-  void evaluate_fused(Array2& p) {
+  void evaluate_harmonics(Array2& p) {
     // retains_K mirrors the branch in ShearAlfvenHarmonic::set_points
     const bool retains_K = (B0->field_type == "nok" || B0->field_type == "");
     const double psi0 = B0->psi0;
@@ -660,16 +648,16 @@ private:
     auto& data_dGds = retains_K ? B0->dGds_ref() : empty;
     auto& data_dIds = retains_K ? B0->dIds_ref() : empty;
 
-    fused_Phi.resize({npoints, 1});
-    fused_dPhidpsi.resize({npoints, 1});
-    fused_dPhidtheta.resize({npoints, 1});
-    fused_dPhidzeta.resize({npoints, 1});
-    fused_Phidot.resize({npoints, 1});
-    fused_alpha.resize({npoints, 1});
-    fused_alphadot.resize({npoints, 1});
-    fused_dalphadpsi.resize({npoints, 1});
-    fused_dalphadtheta.resize({npoints, 1});
-    fused_dalphadzeta.resize({npoints, 1});
+    total_Phi.resize({npoints, 1});
+    total_dPhidpsi.resize({npoints, 1});
+    total_dPhidtheta.resize({npoints, 1});
+    total_dPhidzeta.resize({npoints, 1});
+    total_Phidot.resize({npoints, 1});
+    total_alpha.resize({npoints, 1});
+    total_alphadot.resize({npoints, 1});
+    total_dalphadpsi.resize({npoints, 1});
+    total_dalphadtheta.resize({npoints, 1});
+    total_dalphadzeta.resize({npoints, 1});
 
     for (long i = 0; i < npoints; ++i) {
       const double s = p(i, 0);
@@ -732,130 +720,60 @@ private:
         sum_dalphadtheta += -dPhidtheta * alpha_fac;
       }
 
-      fused_Phi(i, 0) = sum_Phi;
-      fused_dPhidpsi(i, 0) = sum_dPhidpsi;
-      fused_dPhidtheta(i, 0) = sum_dPhidtheta;
-      fused_dPhidzeta(i, 0) = sum_dPhidzeta;
-      fused_Phidot(i, 0) = sum_Phidot;
+      total_Phi(i, 0) = sum_Phi;
+      total_dPhidpsi(i, 0) = sum_dPhidpsi;
+      total_dPhidtheta(i, 0) = sum_dPhidtheta;
+      total_dPhidzeta(i, 0) = sum_dPhidzeta;
+      total_Phidot(i, 0) = sum_Phidot;
       // alpha and dalphadzeta are only defined when the field retains K; the
       // per-wave path leaves them untouched in the vacuum case, so report
       // zero rather than a stale value.
-      fused_alpha(i, 0) = sum_alpha;
-      fused_dalphadzeta(i, 0) = sum_dalphadzeta;
-      fused_alphadot(i, 0) = sum_alphadot;
-      fused_dalphadpsi(i, 0) = sum_dalphadpsi;
-      fused_dalphadtheta(i, 0) = sum_dalphadtheta;
+      total_alpha(i, 0) = sum_alpha;
+      total_dalphadzeta(i, 0) = sum_dalphadzeta;
+      total_alphadot(i, 0) = sum_alphadot;
+      total_dalphadpsi(i, 0) = sum_dalphadpsi;
+      total_dalphadtheta(i, 0) = sum_dalphadtheta;
     }
   }
 
 protected:
   void _Phi_impl(Array2& Phi) override {
-    if (fused) {
-      Phi = fused_Phi;
-      return;
-    }
-    Phi.fill(0.0);
-    for (const auto& wave : waves) {
-      Phi += wave->Phi();
-    }
+    Phi = total_Phi;
   }
 
   void _dPhidpsi_impl(Array2& dPhidpsi) override {
-    if (fused) {
-      dPhidpsi = fused_dPhidpsi;
-      return;
-    }
-    dPhidpsi.fill(0.0);
-    for (const auto& wave : waves) {
-      dPhidpsi += wave->dPhidpsi();
-    }
+    dPhidpsi = total_dPhidpsi;
   }
 
   void _dPhidtheta_impl(Array2& dPhidtheta) override {
-    if (fused) {
-      dPhidtheta = fused_dPhidtheta;
-      return;
-    }
-    dPhidtheta.fill(0.0);
-    for (const auto& wave : waves) {
-      dPhidtheta += wave->dPhidtheta();
-    }
+    dPhidtheta = total_dPhidtheta;
   }
 
   void _dPhidzeta_impl(Array2& dPhidzeta) override {
-    if (fused) {
-      dPhidzeta = fused_dPhidzeta;
-      return;
-    }
-    dPhidzeta.fill(0.0);
-    for (const auto& wave : waves) {
-      dPhidzeta += wave->dPhidzeta();
-    }
+    dPhidzeta = total_dPhidzeta;
   }
 
   void _Phidot_impl(Array2& Phidot) override {
-    if (fused) {
-      Phidot = fused_Phidot;
-      return;
-    }
-    Phidot.fill(0.0);
-      for (const auto& wave : waves) {
-      Phidot += wave->Phidot();
-    }
+    Phidot = total_Phidot;
   }
 
   void _alpha_impl(Array2& alpha) override {
-    if (fused) {
-      alpha = fused_alpha;
-      return;
-    }
-    alpha.fill(0.0);
-    for (const auto& wave : waves) {
-      alpha += wave->alpha();
-    }
+    alpha = total_alpha;
   }
 
   void _dalphadpsi_impl(Array2& dalphadpsi) override {
-    if (fused) {
-      dalphadpsi = fused_dalphadpsi;
-      return;
-    }
-    dalphadpsi.fill(0.0);
-    for (const auto& wave : waves) {
-      dalphadpsi += wave->dalphadpsi();
-    }
+    dalphadpsi = total_dalphadpsi;
   }
 
   void _dalphadtheta_impl(Array2& dalphadtheta) override {
-    if (fused) {
-      dalphadtheta = fused_dalphadtheta;
-      return;
-    }
-    dalphadtheta.fill(0.0);
-    for (const auto& wave : waves) {
-      dalphadtheta += wave->dalphadtheta();
-    }
+    dalphadtheta = total_dalphadtheta;
   }
 
   void _dalphadzeta_impl(Array2& dalphadzeta) override {
-    if (fused) {
-      dalphadzeta = fused_dalphadzeta;
-      return;
-    }
-    dalphadzeta.fill(0.0);
-    for (const auto& wave : waves) {
-      dalphadzeta += wave->dalphadzeta();
-    }
+    dalphadzeta = total_dalphadzeta;
   }
 
   void _alphadot_impl(Array2& alphadot) override {
-    if (fused) {
-      alphadot = fused_alphadot;
-      return;
-    }
-    alphadot.fill(0.0);
-    for (const auto& wave : waves) {
-      alphadot += wave->alphadot();
-    }
+    alphadot = total_alphadot;
   }
 };

--- a/src/firm3dpp/shearalfvenwave.h
+++ b/src/firm3dpp/shearalfvenwave.h
@@ -689,7 +689,6 @@ private:
             (iota * h->Phim - h->Phin) / (h->omega * denom);
         double d_alpha_fac_dpsi = (diotadpsi * h->Phim) / (h->omega * denom);
         if (!vacuum) {
-          // Only away from vacuum do G and I themselves vary with psi.
           d_alpha_fac_dpsi -=
               alpha_fac / denom * (dGdpsi + diotadpsi * I + iota * dIdpsi);
         }

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -1390,7 +1390,7 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
         )
         s = np.linspace(0.0, 1.0, 32)
 
-        for retains_K in (False, True):
+        for vacuum in (True, False):
             kw = {
                 "etabar": 1.2,
                 "B0": 5.0,
@@ -1399,10 +1399,10 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
                 "psi0": 0.8,
                 "iota0": 0.4,
             }
-            if retains_K:
+            if not vacuum:
                 kw.update(I0=0.3, I1=0.05)
             field = BoozerAnalytic(**kw)
-            if retains_K:
+            if not vacuum:
                 field.field_type = "nok"
 
             harmonics = [
@@ -1446,7 +1446,7 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
                     expected[q],
                     rtol=1e-12,
                     atol=0,
-                    err_msg=f"{q} (retains_K={retains_K})",
+                    err_msg=f"{q} (vacuum={vacuum})",
                 )
 
     def test_add_wave_refreshes_stored_quantities(self):

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -1370,6 +1370,30 @@ class TestingBoozerSplineField(unittest.TestCase):
 
 
 class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
+    @staticmethod
+    def _harmonics(field, n):
+        """
+        A set of n harmonics on `field`, differing in mode numbers, frequency,
+        phase and amplitude.
+
+        """
+        s = np.linspace(0.0, 1.0, 32)
+        harmonics = []
+        for i in range(n):
+            m = 1 + (i % 5)
+            phihat = 1e3 * s ** (m / 2) * (1 - s) / (i + 1)
+            harmonics.append(
+                ShearAlfvenHarmonic(
+                    (s.tolist(), phihat.tolist()),
+                    m,
+                    1 + (i % 3),
+                    136041.0 * (1 + 0.01 * i),
+                    0.1 * i,
+                    field,
+                )
+            )
+        return harmonics
+
     def test_superposition_equals_sum_of_harmonics(self):
         """
         A superposition evaluates all of its harmonics in one pass rather than
@@ -1388,7 +1412,6 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
                 ]
             )
         )
-        s = np.linspace(0.0, 1.0, 32)
 
         for vacuum in (True, False):
             kw = {
@@ -1405,17 +1428,7 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
             if not vacuum:
                 field.field_type = "nok"
 
-            harmonics = [
-                ShearAlfvenHarmonic(
-                    (s.tolist(), (-1.5e3 * (1 - s**2) / (i + 1)).tolist()),
-                    1 + (i % 5),
-                    1 + (i % 3),
-                    136041.0 * (1 + 0.01 * i),
-                    0.1 * i,
-                    field,
-                )
-                for i in range(6)
-            ]
+            harmonics = self._harmonics(field, 6)
             saw = ShearAlfvenWavesSuperposition(harmonics)
 
             quantities = [
@@ -1457,22 +1470,11 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
         them: without that, a read taken after add_wave silently reports the
         total from before the addition.
         """
-        s = np.linspace(0.0, 1.0, 32)
         field = BoozerAnalytic(
             etabar=1.2, B0=5.0, N=0, G0=3.0, psi0=0.8, iota0=0.4, I0=0.3, I1=0.05
         )
         field.field_type = "nok"
-        points = np.ascontiguousarray(np.array([[0.5, 0.3, 0.7, 1e-5]]))
-
-        def harmonic(i):
-            return ShearAlfvenHarmonic(
-                (s.tolist(), (-1.5e3 * (1 - s**2) / (i + 1)).tolist()),
-                1 + (i % 5),
-                1 + (i % 3),
-                136041.0 * (1 + 0.01 * i),
-                0.1 * i,
-                field,
-            )
+        points = np.ascontiguousarray(np.array([[0.62, 0.3, 0.7, 1e-5]]))
 
         quantities = [
             "Phi",
@@ -1487,7 +1489,7 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
             "dalphadzeta",
         ]
 
-        first, second = harmonic(0), harmonic(1)
+        first, second = self._harmonics(field, 2)
         saw = ShearAlfvenWavesSuperposition([first])
         saw.set_points(points)
         before = {q: np.asarray(getattr(saw, q)()).copy() for q in quantities}

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -1370,44 +1370,18 @@ class TestingBoozerSplineField(unittest.TestCase):
 
 
 class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
-    """
-    A superposition of ShearAlfvenHarmonics is evaluated in a single fused pass
-    rather than by giving the points to every wave and summing per-wave arrays.
-    These check that the fused result is the sum of the individual harmonics,
-    that inspecting a single wave still works, and that a superposition which
-    cannot be fused falls back to the generic path.
-    """
-
-    NHARM = 6
-
-    def _field(self, retains_K=False):
-        kw = {"etabar": 1.2, "B0": 5.0, "N": 0, "G0": 3.0, "psi0": 0.8, "iota0": 0.4}
-        if retains_K:
-            kw.update(I0=0.3, I1=0.05)
-        field = BoozerAnalytic(**kw)
-        if retains_K:
-            field.field_type = "nok"
-        return field
-
-    def _harmonics(self, field, n=None):
-        n = n or self.NHARM
-        s = np.linspace(0.0, 1.0, 32)
-        return [
-            ShearAlfvenHarmonic(
-                (s.tolist(), (-1.5e3 * (1 - s**2) / (i + 1)).tolist()),
-                1 + (i % 5),
-                1 + (i % 3),
-                136041.0 * (1 + 0.01 * i),
-                0.1 * i,
-                field,
-            )
-            for i in range(n)
-        ]
-
-    @staticmethod
-    def _points(npts=64, seed=0):
-        rng = np.random.default_rng(seed)
-        return np.ascontiguousarray(
+    def test_superposition_equals_sum_of_harmonics(self):
+        """
+        A superposition evaluates all of its harmonics in one pass rather than
+        wave by wave, so check the result against summing the harmonics
+        individually. Both field types are covered, since the vacuum branch and
+        the one that retains K build the alpha factors differently. alpha and
+        dalphadzeta are only assigned when K is retained, so they are only
+        comparable in that case.
+        """
+        rng = np.random.default_rng(0)
+        npts = 64
+        points = np.ascontiguousarray(
             np.column_stack(
                 [
                     rng.uniform(0.05, 0.95, npts),
@@ -1417,11 +1391,36 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
                 ]
             )
         )
+        s = np.linspace(0.0, 1.0, 32)
 
-    def test_superposition_equals_sum_of_harmonics(self):
-        # alpha and dalphadzeta are only assigned when the field retains K, so
-        # they are only comparable in that case.
         for retains_K in (False, True):
+            kw = {
+                "etabar": 1.2,
+                "B0": 5.0,
+                "N": 0,
+                "G0": 3.0,
+                "psi0": 0.8,
+                "iota0": 0.4,
+            }
+            if retains_K:
+                kw.update(I0=0.3, I1=0.05)
+            field = BoozerAnalytic(**kw)
+            if retains_K:
+                field.field_type = "nok"
+
+            harmonics = [
+                ShearAlfvenHarmonic(
+                    (s.tolist(), (-1.5e3 * (1 - s**2) / (i + 1)).tolist()),
+                    1 + (i % 5),
+                    1 + (i % 3),
+                    136041.0 * (1 + 0.01 * i),
+                    0.1 * i,
+                    field,
+                )
+                for i in range(6)
+            ]
+            saw = ShearAlfvenWavesSuperposition(harmonics)
+
             quantities = [
                 "Phi",
                 "dPhidpsi",
@@ -1435,70 +1434,23 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
             if retains_K:
                 quantities += ["alpha", "dalphadzeta"]
 
-            with self.subTest(retains_K=retains_K):
-                field = self._field(retains_K)
-                harmonics = self._harmonics(field)
-                saw = ShearAlfvenWavesSuperposition(harmonics)
-                points = self._points()
+            saw.set_points(points)
+            fused = {q: np.asarray(getattr(saw, q)()).copy() for q in quantities}
 
-                saw.set_points(points)
-                fused = {q: np.asarray(getattr(saw, q)()).copy() for q in quantities}
-
-                expected = dict.fromkeys(quantities, 0.0)
-                for h in harmonics:
-                    h.set_points(points)
-                    for q in quantities:
-                        expected[q] = expected[q] + np.asarray(getattr(h, q)())
-
+            expected = dict.fromkeys(quantities, 0.0)
+            for harmonic in harmonics:
+                harmonic.set_points(points)
                 for q in quantities:
-                    np.testing.assert_allclose(
-                        fused[q], expected[q], rtol=1e-12, atol=0, err_msg=q
-                    )
+                    expected[q] = expected[q] + np.asarray(getattr(harmonic, q)())
 
-    def test_single_point_matches_batch(self):
-        """Tracing evaluates one point at a time; that must match a batch."""
-        field = self._field()
-        saw = ShearAlfvenWavesSuperposition(self._harmonics(field))
-        points = self._points(npts=16, seed=3)
-
-        saw.set_points(points)
-        batch = np.asarray(saw.dPhidpsi()).copy()
-
-        for i in range(points.shape[0]):
-            saw.set_points(np.ascontiguousarray(points[i : i + 1]))
-            self.assertAlmostEqual(
-                float(np.asarray(saw.dPhidpsi())[0, 0]), float(batch[i, 0]), places=12
-            )
-
-    def test_get_wave_is_up_to_date(self):
-        """An individual wave must still be queryable after set_points."""
-        field = self._field()
-        harmonics = self._harmonics(field)
-        saw = ShearAlfvenWavesSuperposition(harmonics)
-        points = self._points(npts=8, seed=5)
-        saw.set_points(points)
-
-        wave = saw.get_wave(2)
-        got = np.asarray(wave.Phi()).copy()
-
-        harmonics[2].set_points(points)
-        np.testing.assert_allclose(got, np.asarray(harmonics[2].Phi()), rtol=1e-13)
-
-    def test_only_harmonics_accepted(self):
-        """
-        The superposition evaluates its harmonics together in one pass, so it
-        only accepts ShearAlfvenHarmonics. Anything else is rejected when it is
-        added rather than silently taking a different path.
-        """
-        field = self._field()
-        inner = ShearAlfvenWavesSuperposition(self._harmonics(field, n=2))
-
-        with self.assertRaises(ValueError):
-            ShearAlfvenWavesSuperposition([inner] + self._harmonics(field, n=2))
-
-        saw = ShearAlfvenWavesSuperposition(self._harmonics(field, n=2))
-        with self.assertRaises(ValueError):
-            saw.add_wave(inner)
+            for q in quantities:
+                np.testing.assert_allclose(
+                    fused[q],
+                    expected[q],
+                    rtol=1e-12,
+                    atol=0,
+                    err_msg=f"{q} (retains_K={retains_K})",
+                )
 
 
 class TestInterpolatedShearAlfvenWave(unittest.TestCase):

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -1374,10 +1374,7 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
         """
         A superposition evaluates all of its harmonics in one pass rather than
         wave by wave, so check the result against summing the harmonics
-        individually. Both field types are covered, since the vacuum branch and
-        the one that retains K build the alpha factors differently. alpha and
-        dalphadzeta are only assigned when K is retained, so they are only
-        comparable in that case.
+        individually.
         """
         rng = np.random.default_rng(0)
         npts = 64
@@ -1427,12 +1424,12 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
                 "dPhidtheta",
                 "dPhidzeta",
                 "Phidot",
+                "alpha",
                 "alphadot",
                 "dalphadpsi",
                 "dalphadtheta",
+                "dalphadzeta",
             ]
-            if retains_K:
-                quantities += ["alpha", "dalphadzeta"]
 
             saw.set_points(points)
             fused = {q: np.asarray(getattr(saw, q)()).copy() for q in quantities}

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -14,6 +14,7 @@ from firm3d.field.boozermagneticfield import (
     BoozerSplineField,
     InterpolatedBoozerField,
     InterpolatedShearAlfvenWave,
+    ShearAlfvenHarmonic,
     ShearAlfvenWavesSuperposition,
 )
 from firm3d.saw.ae3d import AE3DEigenvector
@@ -1366,6 +1367,140 @@ class TestingBoozerSplineField(unittest.TestCase):
         assert np.allclose(nu_derivs[:, 0], bsf.dnuds()[:, 0])
         assert np.allclose(nu_derivs[:, 1], bsf.dnudtheta()[:, 0])
         assert np.allclose(nu_derivs[:, 2], bsf.dnudzeta()[:, 0])
+
+
+class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
+    """
+    A superposition of ShearAlfvenHarmonics is evaluated in a single fused pass
+    rather than by giving the points to every wave and summing per-wave arrays.
+    These check that the fused result is the sum of the individual harmonics,
+    that inspecting a single wave still works, and that a superposition which
+    cannot be fused falls back to the generic path.
+    """
+
+    NHARM = 6
+
+    def _field(self, retains_K=False):
+        kw = {"etabar": 1.2, "B0": 5.0, "N": 0, "G0": 3.0, "psi0": 0.8, "iota0": 0.4}
+        if retains_K:
+            kw.update(I0=0.3, I1=0.05)
+        field = BoozerAnalytic(**kw)
+        if retains_K:
+            field.field_type = "nok"
+        return field
+
+    def _harmonics(self, field, n=None):
+        n = n or self.NHARM
+        s = np.linspace(0.0, 1.0, 32)
+        return [
+            ShearAlfvenHarmonic(
+                (s.tolist(), (-1.5e3 * (1 - s**2) / (i + 1)).tolist()),
+                1 + (i % 5),
+                1 + (i % 3),
+                136041.0 * (1 + 0.01 * i),
+                0.1 * i,
+                field,
+            )
+            for i in range(n)
+        ]
+
+    @staticmethod
+    def _points(npts=64, seed=0):
+        rng = np.random.default_rng(seed)
+        return np.ascontiguousarray(
+            np.column_stack(
+                [
+                    rng.uniform(0.05, 0.95, npts),
+                    rng.uniform(0.0, 2 * np.pi, npts),
+                    rng.uniform(0.0, 2 * np.pi, npts),
+                    rng.uniform(0.0, 1e-4, npts),
+                ]
+            )
+        )
+
+    def test_superposition_equals_sum_of_harmonics(self):
+        # alpha and dalphadzeta are only assigned when the field retains K, so
+        # they are only comparable in that case.
+        for retains_K in (False, True):
+            quantities = [
+                "Phi",
+                "dPhidpsi",
+                "dPhidtheta",
+                "dPhidzeta",
+                "Phidot",
+                "alphadot",
+                "dalphadpsi",
+                "dalphadtheta",
+            ]
+            if retains_K:
+                quantities += ["alpha", "dalphadzeta"]
+
+            with self.subTest(retains_K=retains_K):
+                field = self._field(retains_K)
+                harmonics = self._harmonics(field)
+                saw = ShearAlfvenWavesSuperposition(harmonics)
+                points = self._points()
+
+                saw.set_points(points)
+                fused = {q: np.asarray(getattr(saw, q)()).copy() for q in quantities}
+
+                expected = dict.fromkeys(quantities, 0.0)
+                for h in harmonics:
+                    h.set_points(points)
+                    for q in quantities:
+                        expected[q] = expected[q] + np.asarray(getattr(h, q)())
+
+                for q in quantities:
+                    np.testing.assert_allclose(
+                        fused[q], expected[q], rtol=1e-12, atol=0, err_msg=q
+                    )
+
+    def test_single_point_matches_batch(self):
+        """Tracing evaluates one point at a time; that must match a batch."""
+        field = self._field()
+        saw = ShearAlfvenWavesSuperposition(self._harmonics(field))
+        points = self._points(npts=16, seed=3)
+
+        saw.set_points(points)
+        batch = np.asarray(saw.dPhidpsi()).copy()
+
+        for i in range(points.shape[0]):
+            saw.set_points(np.ascontiguousarray(points[i : i + 1]))
+            self.assertAlmostEqual(
+                float(np.asarray(saw.dPhidpsi())[0, 0]), float(batch[i, 0]), places=12
+            )
+
+    def test_get_wave_is_up_to_date(self):
+        """An individual wave must still be queryable after set_points."""
+        field = self._field()
+        harmonics = self._harmonics(field)
+        saw = ShearAlfvenWavesSuperposition(harmonics)
+        points = self._points(npts=8, seed=5)
+        saw.set_points(points)
+
+        wave = saw.get_wave(2)
+        got = np.asarray(wave.Phi()).copy()
+
+        harmonics[2].set_points(points)
+        np.testing.assert_allclose(got, np.asarray(harmonics[2].Phi()), rtol=1e-13)
+
+    def test_nested_superposition_falls_back(self):
+        """A wave that is not a plain harmonic disables fusion but still works."""
+        field = self._field()
+        inner_harmonics = self._harmonics(field, n=2)
+        inner = ShearAlfvenWavesSuperposition(inner_harmonics)
+        outer_harmonics = self._harmonics(field, n=2)
+        outer = ShearAlfvenWavesSuperposition([inner] + outer_harmonics)
+
+        points = self._points(npts=12, seed=7)
+        outer.set_points(points)
+        got = np.asarray(outer.Phi()).copy()
+
+        expected = 0.0
+        for h in inner_harmonics + outer_harmonics:
+            h.set_points(points)
+            expected = expected + np.asarray(h.Phi())
+        np.testing.assert_allclose(got, expected, rtol=1e-12)
 
 
 class TestInterpolatedShearAlfvenWave(unittest.TestCase):

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -1484,23 +1484,21 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
         harmonics[2].set_points(points)
         np.testing.assert_allclose(got, np.asarray(harmonics[2].Phi()), rtol=1e-13)
 
-    def test_nested_superposition_falls_back(self):
-        """A wave that is not a plain harmonic disables fusion but still works."""
+    def test_only_harmonics_accepted(self):
+        """
+        The superposition evaluates its harmonics together in one pass, so it
+        only accepts ShearAlfvenHarmonics. Anything else is rejected when it is
+        added rather than silently taking a different path.
+        """
         field = self._field()
-        inner_harmonics = self._harmonics(field, n=2)
-        inner = ShearAlfvenWavesSuperposition(inner_harmonics)
-        outer_harmonics = self._harmonics(field, n=2)
-        outer = ShearAlfvenWavesSuperposition([inner] + outer_harmonics)
+        inner = ShearAlfvenWavesSuperposition(self._harmonics(field, n=2))
 
-        points = self._points(npts=12, seed=7)
-        outer.set_points(points)
-        got = np.asarray(outer.Phi()).copy()
+        with self.assertRaises(ValueError):
+            ShearAlfvenWavesSuperposition([inner] + self._harmonics(field, n=2))
 
-        expected = 0.0
-        for h in inner_harmonics + outer_harmonics:
-            h.set_points(points)
-            expected = expected + np.asarray(h.Phi())
-        np.testing.assert_allclose(got, expected, rtol=1e-12)
+        saw = ShearAlfvenWavesSuperposition(self._harmonics(field, n=2))
+        with self.assertRaises(ValueError):
+            saw.add_wave(inner)
 
 
 class TestInterpolatedShearAlfvenWave(unittest.TestCase):

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -1452,6 +1452,70 @@ class TestingShearAlfvenWavesSuperposition(unittest.TestCase):
                     err_msg=f"{q} (retains_K={retains_K})",
                 )
 
+    def test_add_wave_refreshes_stored_quantities(self):
+        """
+        The superposition accumulates its harmonics into one set of arrays when
+        set_points is called, and every accessor hands back one of those arrays
+        directly. Adding a harmonic afterwards therefore has to re-evaluate
+        them: without that, a read taken after add_wave silently reports the
+        total from before the addition.
+        """
+        s = np.linspace(0.0, 1.0, 32)
+        field = BoozerAnalytic(
+            etabar=1.2, B0=5.0, N=0, G0=3.0, psi0=0.8, iota0=0.4, I0=0.3, I1=0.05
+        )
+        field.field_type = "nok"
+        points = np.ascontiguousarray(np.array([[0.5, 0.3, 0.7, 1e-5]]))
+
+        def harmonic(i):
+            return ShearAlfvenHarmonic(
+                (s.tolist(), (-1.5e3 * (1 - s**2) / (i + 1)).tolist()),
+                1 + (i % 5),
+                1 + (i % 3),
+                136041.0 * (1 + 0.01 * i),
+                0.1 * i,
+                field,
+            )
+
+        quantities = [
+            "Phi",
+            "dPhidpsi",
+            "dPhidtheta",
+            "dPhidzeta",
+            "Phidot",
+            "alpha",
+            "alphadot",
+            "dalphadpsi",
+            "dalphadtheta",
+            "dalphadzeta",
+        ]
+
+        first, second = harmonic(0), harmonic(1)
+        saw = ShearAlfvenWavesSuperposition([first])
+        saw.set_points(points)
+        before = {q: np.asarray(getattr(saw, q)()).copy() for q in quantities}
+
+        # No set_points between the addition and the reads below.
+        saw.add_wave(second)
+        after = {q: np.asarray(getattr(saw, q)()).copy() for q in quantities}
+
+        expected = dict.fromkeys(quantities, 0.0)
+        for h in (first, second):
+            h.set_points(points)
+            for q in quantities:
+                expected[q] = expected[q] + np.asarray(getattr(h, q)())
+
+        for q in quantities:
+            np.testing.assert_allclose(
+                after[q], expected[q], rtol=1e-12, atol=0, err_msg=q
+            )
+            # Guard against the assertion above passing on a quantity that the
+            # second harmonic happens not to move.
+            assert not np.array_equal(after[q], before[q]), (
+                f"{q} is unchanged by add_wave, so it cannot distinguish a "
+                f"refreshed total from a stale one"
+            )
+
 
 class TestInterpolatedShearAlfvenWave(unittest.TestCase):
     """


### PR DESCRIPTION
Evaluation of field from ShearAlfvenWaveSuperposition is performed on a "single pass" for all harmonics, rather than summing evaluations of each individual harmonic. This makes tracing time roughly independent of the number of harmonics. This reduces the AE3D and FAR3D example runtimes to < 10 min. on Perlmutter. 