### PR TITLE
Speed up InterpolatedBoozerField setup and fix three BoozerRadialInterpolant evaluation bugs

### DIFF
--- a/src/firm3d/field/boozermagneticfield.py
+++ b/src/firm3d/field/boozermagneticfield.py
@@ -3044,12 +3044,6 @@ class BoozerRadialInterpolant(BoozerMagneticField):
         # Create minimal arrays for single point computation
         us = np.array([s])
 
-        # The single-point branch of the C++ kernel vectorizes over the mode
-        # index with *aligned* SIMD loads, so the mode-indexed arrays must be
-        # aligned and padded to the SIMD width (on x86, unaligned or
-        # non-padded arrays crash or give garbage; this also converts xm_b /
-        # xn_b when booz_xform hands them over as integers). The multi-point
-        # branch has no such requirement on these arrays.
         chunk_mn = align_and_pad(coeffs(us).reshape(-1))
         xm = align_and_pad(self.xm_b)
         xn = align_and_pad(self.xn_b)

--- a/src/firm3d/field/boozermagneticfield.py
+++ b/src/firm3d/field/boozermagneticfield.py
@@ -2569,321 +2569,158 @@ class BoozerRadialInterpolant(BoozerMagneticField):
         if self.no_K:
             return
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.kmns_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_odd
-
-        self._compute_impl(K[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(K[:, 0], self.kmns_splines, "odd")
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.kmnc_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_even
-
-            self._compute_impl(K[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(K[:, 0], self.kmnc_splines, "even")
 
     def _dKdtheta_impl(self, dKdtheta):
         dKdtheta[:, 0] = 0.0
         if self.no_K:
             return
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.kmns_splines(s)[:, im] * self.xm_b[im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(dKdtheta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dKdtheta[:, 0], lambda s: self.kmns_splines(s) * self.xm_b, "even"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return -self.kmnc_splines(s)[:, im] * self.xm_b[im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_odd
-
-            self._compute_impl(dKdtheta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dKdtheta[:, 0], lambda s: -self.kmnc_splines(s) * self.xm_b, "odd"
+            )
 
     def _dKdzeta_impl(self, dKdzeta):
         dKdzeta[:, 0] = 0.0
         if self.no_K:
             return
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return -self.kmns_splines(s)[:, im] * self.xn_b[im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(dKdzeta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dKdzeta[:, 0], lambda s: -self.kmns_splines(s) * self.xn_b, "even"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.kmnc_splines(s)[:, im] * self.xn_b[im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_odd
-
-            self._compute_impl(dKdzeta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dKdzeta[:, 0], lambda s: self.kmnc_splines(s) * self.xn_b, "odd"
+            )
 
     def _nu_impl(self, nu):
         nu[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.numns_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_odd
-
-        self._compute_impl(nu[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(nu[:, 0], self.numns_splines, "odd")
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.numnc_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_even
-
-            self._compute_impl(nu[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(nu[:, 0], self.numnc_splines, "even")
 
     def _dnudtheta_impl(self, dnudtheta):
         dnudtheta[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.numns_splines(s)[:, im] * self.xm_b[im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(dnudtheta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dnudtheta[:, 0], lambda s: self.numns_splines(s) * self.xm_b, "even"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return -self.numnc_splines(s)[:, im] * self.xm_b[im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_odd
-
-            self._compute_impl(dnudtheta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dnudtheta[:, 0], lambda s: -self.numnc_splines(s) * self.xm_b, "odd"
+            )
 
     def _dnudzeta_impl(self, dnudzeta):
         dnudzeta[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return -self.numns_splines(s)[:, im] * self.xn_b[im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(dnudzeta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dnudzeta[:, 0], lambda s: -self.numns_splines(s) * self.xn_b, "even"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.numnc_splines(s)[:, im] * self.xn_b[im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_odd
-
-            self._compute_impl(dnudzeta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dnudzeta[:, 0], lambda s: self.numnc_splines(s) * self.xn_b, "odd"
+            )
 
     def _dnuds_impl(self, dnuds):
         dnuds[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.dnumnsds_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_odd
-
-        self._compute_impl(dnuds[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(dnuds[:, 0], self.dnumnsds_splines, "odd")
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.dnumncds_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_even
-
-            self._compute_impl(dnuds[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(dnuds[:, 0], self.dnumncds_splines, "even")
 
     def _dRdtheta_impl(self, dRdtheta):
         dRdtheta[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return -self.rmnc_splines(s)[:, im] * self.xm_b[im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_odd
-
-        self._compute_impl(dRdtheta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dRdtheta[:, 0], lambda s: -self.rmnc_splines(s) * self.xm_b, "odd"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.rmns_splines(s)[:, im] * self.xm_b[im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_even
-
-            self._compute_impl(dRdtheta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dRdtheta[:, 0], lambda s: self.rmns_splines(s) * self.xm_b, "even"
+            )
 
     def _dRdzeta_impl(self, dRdzeta):
         dRdzeta[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.rmnc_splines(s)[:, im] * self.xn_b[im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_odd
-
-        self._compute_impl(dRdzeta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dRdzeta[:, 0], lambda s: self.rmnc_splines(s) * self.xn_b, "odd"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return -self.rmns_splines(s)[:, im] * self.xn_b[im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_even
-
-            self._compute_impl(dRdzeta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dRdzeta[:, 0], lambda s: -self.rmns_splines(s) * self.xn_b, "even"
+            )
 
     def _dRds_impl(self, dRds):
         dRds[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.drmncds_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(dRds[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(dRds[:, 0], self.drmncds_splines, "even")
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.drmnsds_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_odd
-
-            self._compute_impl(dRds[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(dRds[:, 0], self.drmnsds_splines, "odd")
 
     def _R_impl(self, R):
         R[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.rmnc_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(R[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(R[:, 0], self.rmnc_splines, "even")
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.rmns_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_odd
-
-            self._compute_impl(R[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(R[:, 0], self.rmns_splines, "odd")
 
     def _dZdtheta_impl(self, dZdtheta):
         dZdtheta[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.zmns_splines(s)[:, im] * self.xm_b[im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(dZdtheta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dZdtheta[:, 0], lambda s: self.zmns_splines(s) * self.xm_b, "even"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return -self.zmnc_splines(s)[:, im] * self.xm_b[im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_odd
-
-            self._compute_impl(dZdtheta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dZdtheta[:, 0], lambda s: -self.zmnc_splines(s) * self.xm_b, "odd"
+            )
 
     def _dZdzeta_impl(self, dZdzeta):
         dZdzeta[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return -self.zmns_splines(s)[:, im] * self.xn_b[im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(dZdzeta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dZdzeta[:, 0], lambda s: -self.zmns_splines(s) * self.xn_b, "even"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.zmnc_splines(s)[:, im] * self.xn_b[im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_odd
-
-            self._compute_impl(dZdzeta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dZdzeta[:, 0], lambda s: self.zmnc_splines(s) * self.xn_b, "odd"
+            )
 
     def _dZds_impl(self, dZds):
         dZds[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.dzmnsds_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_odd
-
-        self._compute_impl(dZds[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(dZds[:, 0], self.dzmnsds_splines, "odd")
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.dzmncds_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_even
-
-            self._compute_impl(dZds[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(dZds[:, 0], self.dzmncds_splines, "even")
 
     def _Z_impl(self, Z):
         Z[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.zmns_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_odd
-
-        self._compute_impl(Z[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(Z[:, 0], self.zmns_splines, "odd")
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.zmnc_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_even
-
-            self._compute_impl(Z[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(Z[:, 0], self.zmnc_splines, "even")
 
     def _psip_impl(self, psip):
         points = self.get_points_ref()
@@ -2930,92 +2767,68 @@ class BoozerRadialInterpolant(BoozerMagneticField):
     def _modB_impl(self, modB):
         modB[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.bmnc_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(modB[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(modB[:, 0], self.bmnc_splines, "even")
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.bmns_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_odd
-
-            self._compute_impl(modB[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(modB[:, 0], self.bmns_splines, "odd")
 
     def _dmodBdtheta_impl(self, dmodBdtheta):
         dmodBdtheta[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return -self.xm_b[im] * self.bmnc_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_odd
-
-        self._compute_impl(dmodBdtheta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dmodBdtheta[:, 0], lambda s: -self.xm_b * self.bmnc_splines(s), "odd"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.xm_b[im] * self.bmns_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_even
-
-            self._compute_impl(dmodBdtheta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dmodBdtheta[:, 0], lambda s: self.xm_b * self.bmns_splines(s), "even"
+            )
 
     def _dmodBdzeta_impl(self, dmodBdzeta):
         dmodBdzeta[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.xn_b[im] * self.bmnc_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_odd
-
-        self._compute_impl(dmodBdzeta[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(
+            dmodBdzeta[:, 0], lambda s: self.xn_b * self.bmnc_splines(s), "odd"
+        )
 
         if self.asym:
-
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return -self.xn_b[im] * self.bmns_splines(s)[:, im]
-
-            inverse_fourier = sopp.inverse_fourier_transform_even
-
-            self._compute_impl(dmodBdzeta[:, 0], _harmonics, inverse_fourier)
+            self._compute_impl(
+                dmodBdzeta[:, 0], lambda s: -self.xn_b * self.bmns_splines(s), "even"
+            )
 
     def _dmodBds_impl(self, dmodBds):
         dmodBds[:, 0] = 0.0
 
-        @self.iterate_and_invert
-        def _harmonics(im, s):
-            return self.dbmncds_splines(s)[:, im]
-
-        inverse_fourier = sopp.inverse_fourier_transform_even
-
-        self._compute_impl(dmodBds[:, 0], _harmonics, inverse_fourier)
+        self._compute_impl(dmodBds[:, 0], self.dbmncds_splines, "even")
 
         if self.asym:
+            self._compute_impl(dmodBds[:, 0], self.dbmnsds_splines, "odd")
 
-            @self.iterate_and_invert
-            def _harmonics(im, s):
-                return self.dbmnsds_splines(s)[:, im]
+    def _compute_impl(self, output, coeffs, parity):
+        r"""
+        Add to ``output`` the inverse Fourier transform
 
-            inverse_fourier = sopp.inverse_fourier_transform_odd
+        .. math::
+            \sum_{mn} c_{mn}(s) \times \begin{cases}
+                \cos(m\theta - n\zeta) & \text{parity = "even"} \\
+                \sin(m\theta - n\zeta) & \text{parity = "odd"}
+            \end{cases}
 
-            self._compute_impl(dmodBds[:, 0], _harmonics, inverse_fourier)
+        evaluated at the current points.
 
-    def _compute_impl(self, output, harmonics, inverse_fourier):
+        Args:
+            output: 1d array of length ``npoints`` that the result is added to.
+            coeffs: callable mapping an array of ``s`` values to the
+                ``(len(s), nmodes)`` array of radial coefficients
+                :math:`c_{mn}(s)` for every Boozer mode. It is called once,
+                on the unique ``s`` values of the current point set.
+            parity: ``"even"`` or ``"odd"``, selecting cosine or sine.
+        """
+        assert parity in ("even", "odd")
         # Fast path for single point evaluation
         points = self.get_points_ref()
         if len(points) == 1:
-            return self._compute_single_point(output, harmonics, inverse_fourier)
+            return self._compute_single_point(output, coeffs, parity)
 
         if self.comm is not None:
             size = self.comm.size
@@ -3043,100 +2856,183 @@ class BoozerRadialInterpolant(BoozerMagneticField):
         zetas = points[:, 2]
         us, inv = np.unique(s, return_inverse=True)
 
+        # Evaluate the radial coefficients for every mode this rank owns. The
+        # splines are vector valued over the mode index, so this is a single
+        # call for all modes, on the unique s values only.
+        cmn = coeffs(us)[:, first_mn:last_mn]
+
+        result = self._sum_harmonics_separable(
+            cmn, inv, thetas, zetas, parity, first_mn, last_mn
+        )
+        if result is None:
+            result = self._sum_harmonics_pointwise(
+                cmn, inv, thetas, zetas, parity, first_mn, last_mn
+            )
+
+        if self.comm is not None:
+            # In place reduce is slightly slower
+            # self.mpi.comm_world.Allreduce(MPI.IN_PLACE,
+            # [result, MPI.DOUBLE], op=MPI.SUM)
+            self.comm.Allreduce([result, MPI.DOUBLE], recv_buffer, op=MPI.SUM)
+            output += recv_buffer
+        else:
+            output += result
+
+    def _sum_harmonics_pointwise(
+        self, cmn, inv, thetas, zetas, parity, first_mn, last_mn
+    ):
+        """
+        Sum the Fourier series one point at a time, in C++. Cost is
+        ``npoints * nmodes``; used for scattered points, where the point set
+        has no exploitable structure.
+        """
+        npoints = len(inv)
+
         # Pre-allocate and reuse buffers if possible
         if not hasattr(self, "_compute_buffers"):
             self._compute_buffers = {}
 
-        if len(s) > 1:
-            # Pre-compute padded arrays only when needed
-            if not hasattr(self, "_padded_cache") or len(self._padded_cache) != len(s):
-                self._padded_cache = {
-                    "thetas": align_and_pad(thetas),
-                    "zetas": align_and_pad(zetas),
-                }
+        # align_and_pad returns its argument untouched when it is already
+        # aligned and padded, so there is nothing to cache here.
+        padded_thetas = align_and_pad(thetas)
+        padded_zetas = align_and_pad(zetas)
 
-            padded_thetas = self._padded_cache["thetas"]
-            padded_zetas = self._padded_cache["zetas"]
+        # Optimize buffer allocation with better key strategy
+        buffer_key = ("padded", npoints)
+        if buffer_key not in self._compute_buffers:
+            self._compute_buffers[buffer_key] = allocate_aligned_and_padded_array(
+                (npoints,)
+            )
+        padded_buffer = self._compute_buffers[buffer_key]
 
-            # Optimize buffer allocation with better key strategy
-            buffer_key = ("padded", output.shape, len(s))
-            if buffer_key not in self._compute_buffers:
-                self._compute_buffers[buffer_key] = allocate_aligned_and_padded_array(
-                    output.shape
-                )
-            padded_buffer = self._compute_buffers[buffer_key]
+        # Use memset-like operation for faster clearing
+        if padded_buffer.size > 0:
+            padded_buffer.fill(0)
 
-            # Use memset-like operation for faster clearing
-            if padded_buffer.size > 0:
-                padded_buffer.fill(0)
+        # Optimize chunk allocation with better sizing
+        chunk_key = ("chunk", (last_mn - first_mn, npoints))
+        if chunk_key not in self._compute_buffers:
+            self._compute_buffers[chunk_key] = allocate_aligned_and_padded_array(
+                (last_mn - first_mn, npoints)
+            )
+        chunk_mn = self._compute_buffers[chunk_key]
+        # Broadcast the per-unique-s coefficients out to one column per point.
+        # take(..., out=) writes straight into the buffer; assigning
+        # cmn.T[:, inv] instead would materialize a second array of the same
+        # (nmodes, npoints) size.
+        np.take(cmn.T, inv, axis=1, out=chunk_mn[:, :npoints])
 
-            # Optimize chunk allocation with better sizing
-            chunk_key = ("chunk", (last_mn - first_mn, len(inv)))
-            if chunk_key not in self._compute_buffers:
-                self._compute_buffers[chunk_key] = allocate_aligned_and_padded_array(
-                    (last_mn - first_mn, len(inv))
-                )
-            chunk_mn = self._compute_buffers[chunk_key]
-
-            # release memory manually. maybe not be needed anymore
-            s, thetas, zetas = None, None, None
-            harmonics(us, chunk_mn, inv, 0, last_mn - first_mn, first_mn)
-            xm = self.xm_b[first_mn:last_mn]
-            xn = self.xn_b[first_mn:last_mn]
-        else:
-            padded_thetas = thetas
-            padded_zetas = zetas
-            padded_buffer = np.zeros(output.shape)
-
-            # Reuse chunk_mn for scalar case
-            chunk_key = ("chunk_scalar", (last_mn - first_mn,))
-            if chunk_key not in self._compute_buffers:
-                self._compute_buffers[chunk_key] = allocate_aligned_and_padded_array(
-                    (last_mn - first_mn,)
-                )
-            chunk_mn = self._compute_buffers[chunk_key]
-
-            harmonics(us, chunk_mn, inv, 0, last_mn - first_mn, first_mn)
-            xm = align_and_pad(self.xm_b[first_mn:last_mn])
-            xn = align_and_pad(self.xn_b[first_mn:last_mn])
-
+        inverse_fourier = (
+            sopp.inverse_fourier_transform_even
+            if parity == "even"
+            else sopp.inverse_fourier_transform_odd
+        )
         inverse_fourier(
             padded_buffer,
             chunk_mn,
-            xm,
-            xn,
+            self.xm_b[first_mn:last_mn],
+            self.xn_b[first_mn:last_mn],
             padded_thetas,
             padded_zetas,
             self.ntor,
             self.nfp,
             False,
         )
-        chunk_mn, padded_thetas, padded_zetas = None, None, None
+        return padded_buffer[:npoints]
 
-        if self.comm is not None:
-            # In place reduce is slightly slower
-            # self.mpi.comm_world.Allreduce(MPI.IN_PLACE,
-            # [padded_buffer[:len(inv)], MPI.DOUBLE], op=MPI.SUM)
-            self.comm.Allreduce(
-                [padded_buffer[: len(inv)], MPI.DOUBLE], recv_buffer, op=MPI.SUM
-            )
-            output += recv_buffer
+    def _sum_harmonics_separable(
+        self, cmn, inv, thetas, zetas, parity, first_mn, last_mn
+    ):
+        r"""
+        Sum the Fourier series by partial summation over a tensor-product
+        lattice of the distinct :math:`(s, \theta, \zeta)` values, using
+
+        .. math::
+            \sum_{mn} c_{mn}\cos(m\theta - n\zeta)
+              = \sum_m \left[\cos(m\theta) A_m(\zeta)
+                             + \sin(m\theta) B_m(\zeta)\right],
+
+        with :math:`A_m(\zeta) = \sum_n c_{mn}\cos(n\zeta)` and
+        :math:`B_m(\zeta) = \sum_n c_{mn}\sin(n\zeta)`. This replaces the
+        ``npoints * nmodes`` mode loop with four matrix products, which for the
+        grids used to build an :class:`InterpolatedBoozerField` is one to two
+        orders of magnitude cheaper.
+
+        Returns ``None`` when the point set is not separable enough to pay off
+        (e.g. scattered points), leaving the caller to fall back to
+        :meth:`_sum_harmonics_pointwise`.
+        """
+        npoints = len(inv)
+        nmodes = last_mn - first_mn
+        if npoints < 64 or nmodes == 0:
+            return None
+
+        rect = self._mode_rectangle(first_mn, last_mn)
+        if rect is None:
+            return None
+        m_idx, n_idx, ms, ns_ = rect
+
+        uth, tinv = np.unique(thetas, return_inverse=True)
+        uze, zinv = np.unique(zetas, return_inverse=True)
+        nus, nth, nze = cmn.shape[0], len(uth), len(uze)
+        M, N = len(ms), len(ns_)
+
+        # Only worth it if the lattice of distinct values is small compared to
+        # summing over every mode at every point.
+        lattice = nus * nth * nze
+        cost_lattice = nus * (2 * M * N * nze + 4 * nth * M * nze)
+        cost_pointwise = 4 * npoints * nmodes
+        if lattice > 8 * npoints or cost_lattice > 0.5 * cost_pointwise:
+            return None
+
+        cos_mt = np.cos(np.outer(uth, ms))
+        sin_mt = np.sin(np.outer(uth, ms))
+        angle_z = np.outer(ns_ * self.nfp, uze)
+        cos_nz = np.cos(angle_z)
+        sin_nz = np.sin(angle_z)
+
+        crect = np.zeros((nus, M, N))
+        crect[:, m_idx, n_idx] = cmn
+
+        a_ = crect @ cos_nz  # (nus, M, nze)
+        b_ = crect @ sin_nz
+        if parity == "even":
+            # cos(m theta - n zeta) = cos(m theta) cos(n zeta)
+            #                       + sin(m theta) sin(n zeta)
+            lattice_vals = cos_mt @ a_ + sin_mt @ b_
         else:
-            output += padded_buffer[: len(inv)]
+            # sin(m theta - n zeta) = sin(m theta) cos(n zeta)
+            #                       - cos(m theta) sin(n zeta)
+            lattice_vals = sin_mt @ a_ - cos_mt @ b_
+        return np.ascontiguousarray(lattice_vals[inv, tinv, zinv])
 
-    def iterate_and_invert(self, func):
-        def _f(us, output, inv, start, end, offset):
-            length = len(inv)
-            if length > 1:
-                for im in range(start, end):
-                    output[im, :length] = func(im + offset, us)[inv]
+    def _mode_rectangle(self, first_mn, last_mn):
+        """
+        Index the modes ``[first_mn, last_mn)`` into a dense ``(m, n)``
+        rectangle, which is what makes partial summation possible. Boozer mode
+        tables are rectangular up to a missing half-row at ``m = 0``, so the
+        padding this introduces is negligible. Returns ``None`` if the toroidal
+        mode numbers are not multiples of ``nfp``, or if a mode is repeated, in
+        which case no such rectangle exists.
+        """
+        if not hasattr(self, "_mode_rect_cache"):
+            self._mode_rect_cache = {}
+        key = (first_mn, last_mn)
+        if key not in self._mode_rect_cache:
+            xm = self.xm_b[first_mn:last_mn]
+            xn = self.xn_b[first_mn:last_mn]
+            duplicated = len(np.unique(np.stack([xm, xn], axis=1), axis=0)) != len(xm)
+            if np.any(np.mod(xn, self.nfp) != 0) or duplicated:
+                self._mode_rect_cache[key] = None
             else:
-                for im in range(start, end):
-                    output[im] = func(im + offset, us)[inv]
+                m = np.rint(xm).astype(int)
+                n = np.rint(xn / self.nfp).astype(int)
+                ms = np.arange(m.min(), m.max() + 1)
+                ns_ = np.arange(n.min(), n.max() + 1)
+                self._mode_rect_cache[key] = (m - m.min(), n - n.min(), ms, ns_)
+        return self._mode_rect_cache[key]
 
-        return _f
-
-    def _compute_single_point(self, output, harmonics, inverse_fourier):
+    def _compute_single_point(self, output, coeffs, parity):
         """
         Fast path for single point evaluation - avoids unnecessary allocations
         """
@@ -3147,13 +3043,16 @@ class BoozerRadialInterpolant(BoozerMagneticField):
 
         # Create minimal arrays for single point computation
         us = np.array([s])
-        inv = np.array([0])
 
-        # Allocate minimal buffers
-        chunk_mn = np.zeros((len(self.xm_b), 1))
-
-        # Compute harmonics for the single point
-        harmonics(us, chunk_mn, inv, 0, len(self.xm_b), 0)
+        # The single-point branch of the C++ kernel vectorizes over the mode
+        # index with *aligned* SIMD loads, so the mode-indexed arrays must be
+        # aligned and padded to the SIMD width (on x86, unaligned or
+        # non-padded arrays crash or give garbage; this also converts xm_b /
+        # xn_b when booz_xform hands them over as integers). The multi-point
+        # branch has no such requirement on these arrays.
+        chunk_mn = align_and_pad(coeffs(us).reshape(-1))
+        xm = align_and_pad(self.xm_b)
+        xn = align_and_pad(self.xn_b)
 
         # Create minimal padded arrays
         padded_thetas = np.array([theta])
@@ -3162,12 +3061,16 @@ class BoozerRadialInterpolant(BoozerMagneticField):
         # Allocate minimal output buffer
         padded_buffer = np.zeros((1, 1))
 
-        # Use the inverse_fourier function properly
+        inverse_fourier = (
+            sopp.inverse_fourier_transform_even
+            if parity == "even"
+            else sopp.inverse_fourier_transform_odd
+        )
         inverse_fourier(
             padded_buffer,
-            chunk_mn,
-            self.xm_b,
-            self.xn_b,
+            chunk_mn.reshape(-1, 1),
+            xm,
+            xn,
             padded_thetas,
             padded_zetas,
             self.ntor,
@@ -3176,7 +3079,7 @@ class BoozerRadialInterpolant(BoozerMagneticField):
         )
 
         # Copy result to output
-        output[0] = padded_buffer[0, 0]
+        output[0] += padded_buffer[0, 0]
         return output
 
 

--- a/tests/field/test_boozermagneticfields.py
+++ b/tests/field/test_boozermagneticfields.py
@@ -1144,6 +1144,70 @@ class TestingInverseFourier(unittest.TestCase):
                     assert np.allclose(odd_K[i], odd_output[0], rtol=1e-12, atol=1e-11)
 
 
+class TestingBoozerRadialInterpolantSums(unittest.TestCase):
+    """
+    Check the inverse Fourier sum of BoozerRadialInterpolant against a direct
+    evaluation of the harmonic series, for point sets that exercise each of the
+    evaluation paths: a single point, a repeated small point set, scattered
+    points, and a tensor-product lattice.
+    """
+
+    @staticmethod
+    def _scattered(rng, npoints):
+        return np.column_stack(
+            [
+                rng.uniform(0.1, 0.9, npoints),
+                rng.uniform(0, 2 * np.pi, npoints),
+                rng.uniform(0, 2 * np.pi, npoints),
+            ]
+        )
+
+    @staticmethod
+    def _modB_directly(bri, points):
+        """|B| summed one point and one mode at a time."""
+        modB = np.zeros(len(points))
+        for i, (s, theta, zeta) in enumerate(points):
+            angle = bri.xm_b * theta - bri.xn_b * zeta
+            modB[i] = np.sum(bri.bmnc_splines(np.array([s]))[0] * np.cos(angle))
+            if bri.asym:
+                modB[i] += np.sum(bri.bmns_splines(np.array([s]))[0] * np.sin(angle))
+        return modB
+
+    def test_modB_matches_direct_sum(self):
+        for asym in [True, False]:
+            if asym:
+                bri = BoozerRadialInterpolant(
+                    filename_mhd_lasym, 3, mpol=20, ntor=18, no_K=True, comm=comm
+                )
+            else:
+                bri = BoozerRadialInterpolant(filename_vac, 3, no_K=True, comm=comm)
+            self.assertEqual(bri.asym, asym)
+
+            rng = np.random.default_rng(17)
+            scattered = functools.partial(self._scattered, rng)
+
+            # A lattice of (s, theta, zeta) values, the shape used when
+            # building an InterpolatedBoozerField.
+            thetas = np.linspace(0, 2 * np.pi, 21)
+            zetas = np.linspace(0, 2 * np.pi / bri.nfp, 23)
+            grid = np.meshgrid(np.array([0.3, 0.7]), thetas, zetas, indexing="ij")
+            lattice = np.column_stack([g.ravel() for g in grid])
+
+            point_sets = [scattered(n) for n in (1, 2, 3, 200)]
+            # Evaluate each point set twice, at slightly shifted positions the
+            # second time, so that any state cached from the first call has to
+            # be invalidated.
+            point_sets += [p + 0.01 for p in point_sets]
+            point_sets.append(lattice)
+
+            for points in point_sets:
+                bri.set_points(points)
+                modB = np.asarray(bri.modB()).ravel()
+                assert np.allclose(
+                    modB, self._modB_directly(bri, points), rtol=1e-12, atol=1e-11
+                )
+
+
 class TestingBoozerSplineField(unittest.TestCase):
     def test_boozersplinefield_initialization(self):
         """


### PR DESCRIPTION
## Behavior changes first (bug fixes)

Three latent evaluation bugs in `BoozerRadialInterpolant` are fixed here; anyone bisecting a changed number should look at these before the performance work:

1. **Single-point evaluation of non-stellarator-symmetric fields returned only the sine series.** `_compute_single_point` assigned `output[0] = ...` instead of accumulating, so the odd-parity pass overwrote the even-parity pass (e.g. |B| = −0.014 where the true value is 0.999). Symmetric fields were unaffected (single parity pass).
2. **Evaluating exactly 2 points twice reused the first call's angles.** The padded-array cache guard compared a dict length (always 2) against the point count, so `npoints == 2` always hit a stale cache — errors ~3×10⁻³ in |B|, affecting *all* fields.
3. **x86 crash/garbage in the single-point kernel branch.** The C++ kernel's `num_points == 1` branch does aligned SIMD loads over the mode arrays, which Python passed raw. NEON tolerates the misalignment; AVX2 segfaults or reads garbage (reproduced on Perlmutter, where booz_xform additionally returns `xm_b`/`xn_b` as int32, giving the converted temporaries arbitrary alignment). The mode arrays and coefficients now go through `align_and_pad`.

All three are verified against a brute-force one-point-one-mode evaluation of the harmonic series, and the new regression test fails on master and passes on this branch, on both macOS/arm64 and Perlmutter/x86.

## Performance

`_compute_impl` evaluated the vector-valued radial splines once **per mode**, keeping one column and discarding the rest — quadratic in mode count, 73% of `InterpolatedBoozerField` setup — then broadcast coefficients to a `(nmodes, npoints)` array (604 MB per rank for the production ATEN case) retained for the lifetime of the field.

Now the splines are evaluated once per call, and the sum is dispatched to one of two backends:

- **Partial summation over the dense (m, n) mode rectangle** when the distinct (s, θ, ζ) values form a lattice (the shape of every `InterpolatedBoozerField` build): four matrix products per s-value instead of an `npoints × nmodes` mode loop, and the per-point coefficient array is never materialized.
- **The existing C++ kernel** for scattered points or non-rectangular mode tables — bit-identical to master on this path.

Measured on the production configuration (`boozmn_aten_rescaled.nc`, 4608 modes, order 3, degree 3, resolution 48), Perlmutter CPU node:

| configuration | master | this branch |
|---|---|---|
| serial | 235 s | **1.8 s** |
| 128-rank mode split | 8.3 s | 3.9 s |

At 48³/degree 3 on an M-series laptop with the 3200-mode ARIES-CS test file: 169 s → 1.3 s. Setup no longer benefits from ranks or threads (the 128-rank residual is Allreduce overhead); `comm` remains supported and exact.

## Validation

- All interpolated and direct quantities agree with master to ≤9×10⁻¹⁵ relative (except where master hits bugs 1–2 above), across serial, 4-rank, and 128-rank Perlmutter runs; cross-rank agreement after Allreduce is exactly 0.
- Mode-range splitting reproduces the full-mode sum to ~10⁻¹⁴ for 2/3/5/7-way splits on both backends and both parities.
- `tests/field` suite passes locally except pre-existing environment failures (missing `ndsplines`, no GSL symplectic build).

The 38 per-quantity `_harmonics` closures collapse to one-line coefficient expressions; `iterate_and_invert` is gone. Net −40 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Speed up BoozerRadialInterpolant setup and correct evaluation across parity, repeated-point, and single-point execution paths.

Bug Fixes:
- Fix BoozerRadialInterpolant single-point parity accumulation, stale two-point angle reuse, and x86 single-point kernel alignment issues.

Enhancements:
- Accelerate radial coefficient evaluation and harmonic summation for lattice-based InterpolatedBoozerField setups while retaining the existing path for scattered or irregular modes.
- Simplify harmonic coefficient handling across Boozer field quantities by consolidating evaluation through a shared implementation.

Tests:
- Add regression coverage comparing BoozerRadialInterpolant evaluations across single-point, repeated, scattered, and tensor-product point sets with direct harmonic sums.