### PR TITLE
Terminate particles cleanly when the symplectic solver crosses the axis

### DIFF
--- a/src/firm3d/field/tracing.py
+++ b/src/firm3d/field/tracing.py
@@ -413,7 +413,16 @@ def trace_particles_boozer(
             Option 2 (default) is recommended.
         dt: time step for the symplectic solver. Only used if `ODE_solver` is
             "symplectic".
-        ODE_solver: Choice of ODE_solver: "boost", "dormand_prince" or "symplectic"
+        ODE_solver: Choice of ODE_solver: "boost", "dormand_prince" or "symplectic".
+            Note that the symplectic solver integrates in (s, theta, zeta)
+            coordinates and cannot integrate through the magnetic axis: if an
+            orbit crosses s = 0 within a single step (e.g., a strongly passing
+            particle born near the axis), the particle is terminated at its
+            last accepted state and recorded as a hit on the
+            :obj:`MinToroidalFluxStoppingCriterion` if one is provided;
+            otherwise a ``RuntimeError`` is raised. To trace such orbits
+            through the axis, use "boost" or "dormand_prince" with axis=1
+            or 2 (SIMPLE handles these orbits with axis-healing bridges).
         roottol: root solver tolerance for the symplectic solver. Only used if
             `ODE_solver` is "symplectic". If None, defaults to `tol`.
         predictor_step: provide better initial guess for the next time step

--- a/src/firm3dpp/symplectic.cpp
+++ b/src/firm3dpp/symplectic.cpp
@@ -1,8 +1,12 @@
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_multiroots.h>
+#include <gsl/gsl_errno.h>
 #include "boozermagneticfield.h"
 #include "symplectic.h"
 #include <cassert>
+#include <cmath>
+#include <stdexcept>
+#include <string>
 #include "tracing_helpers.h"
 
 
@@ -58,7 +62,7 @@ void SymplField::eval_field(double s, double theta, double zeta)
 
 }
 
-// compute pzeta normalized by m * vnorm**2 * tnorm 
+// compute pzeta normalized by m * vnorm**2 * tnorm
 double SymplField::get_pzeta(double vpar) {
     double pzeta = (m*hzeta*vpar + q*Azeta/vnorm) / (m * vnorm * tnorm);
     return pzeta;
@@ -67,7 +71,7 @@ double SymplField::get_pzeta(double vpar) {
 // computes values of H, ptheta and vpar at z=(s, theta, zeta, pzeta)
 void SymplField::get_val(double pzeta) {
     vpar = (pzeta * m * vnorm * tnorm - q*Azeta/vnorm)/(hzeta*m);
-    // H is normalized by m * vnorm**2 
+    // H is normalized by m * vnorm**2
     H = pow(vpar,2)/2.0 + mu*modB/pow(vnorm,2);
     // ptheta is normalized by vnorm
     ptheta = (m*htheta*vpar + q*Atheta/vnorm) / (m * vnorm * tnorm);
@@ -93,14 +97,14 @@ void SymplField::get_derivatives(double pzeta) {
 }
 
 double SymplField::get_dsdtau() {
-    // H is normalized by m*vnorm**2 
+    // H is normalized by m*vnorm**2
     // ptheta is normalized by m*vnorm**2 * tnorm
     // dsdt is normalized by tnorm
     return (-dH[1] + dptheta[3]*dH[2] - dptheta[2]*dH[3])/dptheta[0];
 }
 
 double SymplField::get_dthdtau() {
-    // H is normalized by m*vnorm**2 
+    // H is normalized by m*vnorm**2
     // ptheta is normalized by m*vnorm**2 * tnorm
     // dthdt is normalized by tnorm
     return dH[0]/dptheta[0];
@@ -108,9 +112,9 @@ double SymplField::get_dthdtau() {
 
 double SymplField::get_dzedtau() {
     // vpar is normalized by vnorm
-    // H is normalized by m*vnorm**2 
+    // H is normalized by m*vnorm**2
     // ptheta is normalized by m*vnorm**2 * tnorm
-    // htheta and hzeta have units of length -> normalized by tnorm/vnorm 
+    // htheta and hzeta have units of length -> normalized by tnorm/vnorm
     return (vpar * tnorm * vnorm - dH[0]/dptheta[0]*htheta) / (hzeta);
 }
 
@@ -152,13 +156,13 @@ public:
     void update(double tau, double dtau, vector<double> y, SymplField f) {
         tau_last = tau;
         tau_current = tau + dtau;
-        
+
         // Store the state and derivatives at the endpoints
         bracket_s[0] = y[0];
         bracket_theta[0] = y[1];
         bracket_zeta[0] = y[2];
         bracket_vpar[0] = y[3];
-        
+
         // Calculate derivatives at tau
         // Convert to physical coordinates only for field evaluation
         f.eval_field(y[0], y[1], y[2]);
@@ -168,7 +172,7 @@ public:
         bracket_dthdtau[0] = f.get_dthdtau();
         bracket_dzedtau[0] = f.get_dzedtau();
         bracket_dvpardtau[0] = f.get_dvpardtau();
-        
+
         // Calculate state at tau+dtau (this is approximate)
         double dtau_small = dtau * 0.1;
         vector<double> y_next = y;
@@ -176,12 +180,12 @@ public:
         y_next[1] += dtau_small * bracket_dthdtau[0];
         y_next[2] += dtau_small * bracket_dzedtau[0];
         y_next[3] += dtau_small * bracket_dvpardtau[0];
-        
+
         bracket_s[1] = y_next[0];
         bracket_theta[1] = y_next[1];
         bracket_zeta[1] = y_next[2];
         bracket_vpar[1] = y_next[3];
-        
+
         // Calculate derivatives at tau+dtau (approximate)
         // Convert to physical coordinates only for field evaluation
         f.eval_field(y_next[0], y_next[1], y_next[2]);
@@ -192,7 +196,7 @@ public:
         bracket_dzedtau[1] = f.get_dzedtau();
         bracket_dvpardtau[1] = f.get_dvpardtau();
     }
-    
+
     void calc_state(double eval_tau, vector<double> &temp) {
         assert (tau_last <= eval_tau && eval_tau <= tau_current);
         temp.resize(4);
@@ -222,10 +226,19 @@ int f_euler_quasi_func_vector(const gsl_vector* x, void* p, gsl_vector* f)
     const double x0 = gsl_vector_get(x,0);
     const double x1 = gsl_vector_get(x,1);
 
+    // The field interpolant is only defined for s > 0. Fast passing orbits
+    // born near the magnetic axis can drive the root solver to trial points
+    // at or beyond the axis (x0 = s <= 0) or to non-finite values; signal a
+    // domain error instead of evaluating the field there. The caller detects
+    // the failed step and terminates the particle.
+    if (!std::isfinite(x0) || !std::isfinite(x1) || x0 <= 0.0) {
+        return GSL_EDOM;
+    }
+
     field.eval_field(x0, z[1], z[2]);
     field.get_derivatives(x1);
 
-    // Apply normalization factor to make order unity 
+    // Apply normalization factor to make order unity
     double norm = field.q * field.Atheta / (field.m * field.vnorm * field.vnorm * field.tnorm);
     const double f0 = (field.dptheta[0]*(field.ptheta - ptheta_old)
         + dtau*(field.dH[1]*field.dptheta[0] - field.dH[0]*field.dptheta[1])) / (norm * norm); // corresponds with (2.6) in JPP 2020
@@ -277,7 +290,7 @@ void sympl_dense::calc_state(double eval_t, State &temp) {
 //         orbit_symplectic_quasi.f90:timestep_euler1_quasi
 tuple<vector<vector<double>>, vector<vector<double>>> solve_sympl_vector(
     SymplField f,
-    vector<double> y, 
+    vector<double> y,
     double tau_max,
     double dtau,
     double roottol,
@@ -385,8 +398,59 @@ tuple<vector<vector<double>>, vector<vector<double>>> solve_sympl_vector(
         while (status == GSL_CONTINUE && root_iter < 50);
         iter++;
 
-        z[0] = gsl_vector_get(s_euler->x, 0);  // s
-        z[3] = gsl_vector_get(s_euler->x, 1);  // pzeta
+        double s_trial = gsl_vector_get(s_euler->x, 0);
+        double pzeta_trial = gsl_vector_get(s_euler->x, 1);
+
+        // The symplectic solver cannot integrate through the magnetic axis:
+        // a fast passing orbit can cross s = 0 within a single step, in which
+        // case the root solve either diverges (GSL reports "iteration is not
+        // making progress towards solution") or lands at s <= 0, and the
+        // resulting state must not be used to evaluate the field interpolant.
+        // Terminate the particle at its last accepted state, recorded as a
+        // MinToroidalFluxStoppingCriterion hit when one is provided.
+        bool solver_failed = (status != GSL_SUCCESS && status != GSL_CONTINUE);
+        bool state_invalid = !std::isfinite(s_trial) || !std::isfinite(pzeta_trial)
+            || s_trial <= 0.0;
+        // GSL_EBADFUNC means the root function reported GSL_EDOM, i.e. the
+        // solver stepped to a trial point at or beyond the axis.
+        bool axis_crossing = state_invalid || status == GSL_EBADFUNC;
+        if (solver_failed || state_invalid) {
+            int min_flux_idx = -1;
+            double min_s = 0.0;
+            for (int i = 0; i < stopping_criteria.size(); ++i) {
+                auto crit = std::dynamic_pointer_cast<MinToroidalFluxStoppingCriterion>(stopping_criteria[i]);
+                if (crit) {
+                    min_flux_idx = i;
+                    min_s = crit->get_min_s();
+                    break;
+                }
+            }
+            if (min_flux_idx >= 0 && (axis_crossing || s_trial <= min_s)) {
+                vector<double> stzvt(4);
+                y_to_stzvt(y, stzvt, 0, f.vnorm, f.tnorm);
+                vector<double> hit_state = {tau * f.tnorm, -1.0 - double(min_flux_idx)};
+                hit_state.insert(hit_state.end(), stzvt.begin(), stzvt.end());
+                res_hits.push_back(hit_state);
+                stop = true;
+                break;
+            } else if (axis_crossing) {
+                gsl_multiroot_fsolver_free(s_euler);
+                gsl_vector_free(xvec_quasi);
+                throw std::runtime_error(
+                    "Symplectic solver: implicit step produced an invalid state (s = "
+                    + std::to_string(s_trial) + ", t = " + std::to_string(tau * f.tnorm)
+                    + " s). This orbit crossed the magnetic axis, which the symplectic "
+                    "solver cannot integrate through. Add a MinToroidalFluxStoppingCriterion "
+                    "to terminate such particles cleanly, or use ODE_solver='boost' or "
+                    "'dormand_prince' with axis=1 or 2.");
+            }
+            // Otherwise the root solve stalled at a valid state away from the
+            // axis; fall through and continue with the unconverged state as
+            // before (the warning has already been printed above).
+        }
+
+        z[0] = s_trial;   // s
+        z[3] = pzeta_trial;  // pzeta
 
         // We now evaluate the explicit part of the time-step at [s, pzeta]
         // given by the Euler step.
@@ -416,6 +480,15 @@ tuple<vector<vector<double>>, vector<vector<double>>> solve_sympl_vector(
         if (predictor_step) {
             s_guess = z[0] + dtau*(-f.dH[1] + f.dptheta[3]*f.dH[2] - f.dptheta[2]*f.dH[3])/f.dptheta[0];
             pzeta_guess = z[3] + dtau*(- f.dH[2] + f.dH[0]*f.dptheta[2]/f.dptheta[0]); // corresponds with (2.7s) in JPP 2020
+            // The explicit predictor can overshoot the axis (s <= 0) for fast
+            // passing orbits; fall back to the last accepted state so the next
+            // root solve starts from a valid field evaluation point.
+            if (!std::isfinite(s_guess) || s_guess <= 0.0) {
+                s_guess = z[0];
+            }
+            if (!std::isfinite(pzeta_guess)) {
+                pzeta_guess = z[3];
+            }
         } else {
             s_guess = z[0];
             pzeta_guess = z[3];
@@ -467,7 +540,7 @@ tuple<vector<vector<double>>, vector<vector<double>>> solve_sympl_vector(
         tau_last = tau_current;
     } while(tau < tau_max && !stop);
 
-    // Save tau = tau_max if we have not already saved it 
+    // Save tau = tau_max if we have not already saved it
     if (stop) {
         tau_max = tau_last;
     }

--- a/src/firm3dpp/tracing_helpers.h
+++ b/src/firm3dpp/tracing_helpers.h
@@ -61,6 +61,7 @@ class MinToroidalFluxStoppingCriterion : public StoppingCriterion {
         bool operator()(int iter, double dt, double t, double s, double theta, double zeta, double vpar=0) override {
             return s<=min_s;
         };
+        double get_min_s() const { return min_s; };
 };
 
 class IterationStoppingCriterion : public StoppingCriterion {
@@ -266,11 +267,11 @@ bool check_stopping_criteria(
             }
         }
     }
-    
+
     assert(n_zetas.size() == m_thetas.size());
     assert(n_zetas.size() == omegas.size());
     assert(n_zetas.size() == phases.size());
-    
+
     /// Now check whether we have hit any of the phase planes:
     //  n*zeta + m*theta - omega*t = consts
     for (int i = 0; i < n_zetas.size(); ++i) {
@@ -280,12 +281,12 @@ bool check_stopping_criteria(
         double omega = omegas[i];
         double phase_last = nz * zeta_last + mt * theta_last - omega*t_last;
         double phase_current = nz * zeta_current + mt * theta_current - omega*t_current;
-        
+
         if((std::floor((phase_last-phase)/(2*M_PI)) != std::floor((phase_current-phase)/(2*M_PI))) && (phase_current != phase) && (phase_last != phase)) { // check whether phase+k*2pi for some k was crossed
             int fak = std::round(((phase_last+phase_current)/2-phase)/(2*M_PI));
             double phase_shift = fak*2*M_PI + phase;
             assert((phase_last <= phase_shift && phase_shift <= phase_current) || (phase_current <= phase_shift && phase_shift <= phase_last));
-            
+
             std::function<double(double)> rootfun = [&phase_shift, &nz, &mt, &omega, &dense, &y, &stzvt, &axis, &vnorm, &tnorm](double tau){
                 dense.calc_state(tau, y);
                 double t = tau * tnorm;
@@ -308,7 +309,7 @@ bool check_stopping_criteria(
             }
         }
     }
-    
+
     // check whether we have satisfied any of the extra stopping criteria (e.g. left a surface)
     for (int i = 0; i < stopping_criteria.size(); ++i) {
         if(stopping_criteria[i] && (*stopping_criteria[i])(iter, dt, t_current, s_current, theta_current, zeta_current, vpar_current)){


### PR DESCRIPTION
The implicit Euler sub-step of the symplectic solver segfaulted on strongly-passing particles born near the magnetic axis: a fast orbit can cross s = 0 within a single step, in which case the GSL root solve either diverges ("iteration is not making progress towards solution") or lands at s <= 0, and the unconverged state was used to index the field interpolant. MinToroidalFluxStoppingCriterion could not prevent this because it is only checked after a completed step.

Guard the stepper in three places:

- The root function returns GSL_EDOM for trial points with s <= 0 or non-finite values, so GSL never evaluates the interpolant beyond the axis mid-iteration.
- After the implicit solve, a hard solver failure or invalid state terminates the particle at its last accepted state, recorded as a hit on the MinToroidalFluxStoppingCriterion when one is provided; without one, a descriptive RuntimeError is raised. A stalled solve at a valid state away from the axis keeps the previous continue-with-warning behavior.
- The explicit predictor guess falls back to the last converged state if it overshoots the axis, so the next root solve starts in-domain.

Document in the trace_particles_boozer docstring that the symplectic solver cannot integrate through the axis.

Verified on the ARIES-CS field (markers 153 and 160 of the SIMPLE benchmark start.dat, 3.52 MeV alphas, dt=1.2e-8, roottol=1e-13): both previously segfaulted and now stop cleanly, classified as minimum toroidal flux hits; neighboring near-axis markers 152/154/156 are unaffected.