### PR TITLE
Apply only stellsym to the Cartesian coil set

### DIFF
--- a/examples/collisional_slowing_down/README.txt
+++ b/examples/collisional_slowing_down/README.txt
@@ -4,10 +4,9 @@ Over 2e-1 seconds the confined population thermalizes to about 24% of the birth 
 
 On perlmutter (08.13.26), the wallclock time is about 4 minutes using the attached slurm script.
 
-All three collisional examples trace the same equilibrium with the same
-equations and background, and agree: 0.2% of particles lost and about 24% of
-the birth energy retained by the confined population, whether traced on the
-CPU, on the GPU in Boozer coordinates, or on the GPU in Cartesian
-coordinates with the profiles reaching the kick through an interpolated flux
-label.
-
+This example and the gpu_boozer_collisional_tracing example trace the same
+equilibrium field with the same equations and background, and agree: 0.2% of
+particles lost and about 24% of the birth energy retained by the confined
+population. The GPU Cartesian collisional example traces the field of a coil
+set rather than the equilibrium field, so its loss fraction is not expected to
+match.

--- a/examples/gpu_boozer_collisional_tracing/README.txt
+++ b/examples/gpu_boozer_collisional_tracing/README.txt
@@ -6,10 +6,9 @@ Each lost particle takes to the wall only the energy it still had when it crosse
 
 On perlmutter (08.13.26), the wallclock time is about 4 minutes using the attached slurm script.
 
-All three collisional examples trace the same equilibrium with the same
-equations and background, and agree: 0.2% of particles lost and about 24% of
-the birth energy retained by the confined population, whether traced on the
-CPU, on the GPU in Boozer coordinates, or on the GPU in Cartesian
-coordinates with the profiles reaching the kick through an interpolated flux
-label.
-
+This example and the CPU collisional_slowing_down example trace the same
+equilibrium field with the same equations and background, and agree: 0.2% of
+particles lost and about 24% of the birth energy retained by the confined
+population. The GPU Cartesian collisional example traces the field of a coil
+set rather than the equilibrium field, so its loss fraction is not expected to
+match.

--- a/examples/gpu_cartesian_collisional_tracing/README.txt
+++ b/examples/gpu_cartesian_collisional_tracing/README.txt
@@ -1,15 +1,9 @@
-This example traces 1000 alpha particles in the Wistell-A configuration, including Monte Carlo Coulomb collisions with a 50/50 DT background and its electrons. Particles are initialized proportional to the fusion reactivity profile and traced until they leave the plasma boundary or the elapsed time is 2e-1 seconds. Over that window the confined population thermalizes to about 24% of the birth energy, while 0.2% of particles are lost, carrying 0.1% of the birth energy to the wall.
+This example traces 10000 alpha particles in the Wistell-A configuration, including Monte Carlo Coulomb collisions with a 50/50 DT background and its electrons. Particles are initialized proportional to the fusion reactivity profile and traced until they leave the plasma boundary or the elapsed time is 2e-1 seconds. Over that window the confined population thermalizes to about 24% of the birth energy, while 0.88% of particles are lost, carrying 0.50% of the birth energy to the wall.
 
 The thermal profiles are functions of the normalized flux s, which a Cartesian state does not carry, so this entry point takes a flux_label callable mapping cylindrical points (r, phi, z) to s. Its values are interpolated alongside the magnetic field and evaluated at each particle after every accepted step. Here the label is built by mapping a dense Boozer grid of the matching equilibrium forward to cylindrical coordinates and answering queries with the nearest sample; any callable finite over the interpolation grid will do, and values above 1 outside the plasma are clamped by the profile lookup.
 
-The coil field and the equilibrium supplying the label must describe the same device. The label here is built from wout_aten_rescaled.nc, the file the coil set and the boundary classifier come from.
+The coil field and the equilibrium supplying the label must describe the same device. The label here is built from wout_aten_rescaled.nc, the file the coil set and the boundary classifier come from. coils.curves_22_7_21 holds the stellarator-symmetric half of a full-torus 40-coil set, so only stellsym is applied to it.
 
-On perlmutter (08.13.26), the wallclock time is about 5 minutes using the attached slurm script.
+This traces the field of a particular coil set, not the equilibrium field itself, so its loss fraction is not expected to match the two Boozer collisional examples.
 
-All three collisional examples trace the same equilibrium with the same
-equations and background, and agree: 0.2% of particles lost and about 24% of
-the birth energy retained by the confined population, whether traced on the
-CPU, on the GPU in Boozer coordinates, or on the GPU in Cartesian
-coordinates with the profiles reaching the kick through an interpolated flux
-label.
-
+On perlmutter (08.17.26), the wallclock time is about 10 minutes using the attached slurm script.

--- a/examples/gpu_cartesian_collisional_tracing/gpu_cartesian_collisional_tracing.py
+++ b/examples/gpu_cartesian_collisional_tracing/gpu_cartesian_collisional_tracing.py
@@ -33,7 +33,8 @@ from firm3d.util.constants import (
 degree = 3  # degree of interpolant
 n = 16  # resolution of interpolant
 order = 12  # order of coil curves
-nparticles = 1000
+# 10000 rather than 1000 so the loss fraction is not Poisson-limited.
+nparticles = 10000
 tmax = 2e-1
 tol = 1e-8
 
@@ -50,7 +51,9 @@ for _i, coil in enumerate(coils):
     curves.append(coil.curve)
     currents.append(coil.current)
 
-coils_full = coils_via_symmetries(curves, currents, surf.nfp, True)
+# coils.curves_22_7_21 holds the stellarator-symmetric half of a full-torus
+# 40-coil set, so only stellsym is applied here.
+coils_full = coils_via_symmetries(curves, currents, 1, True)
 bs = BiotSavart(coils_full)
 
 sc_particle = SurfaceClassifier(surf, h=0.1, p=2)

--- a/examples/gpu_cartesian_tracing/README.txt
+++ b/examples/gpu_cartesian_tracing/README.txt
@@ -1,3 +1,5 @@
-This example traces 1000 particles in the Wistell-A configuration scaled to the size and field strength of ARIES-CS. Particles are initialized proportional to the fusion reactivity profile and traced until they reach the boundary (s=1) or the elapsed time is 1e-5 seconds. 
+This example traces 1000 particles in the Wistell-A configuration scaled to the size and field strength of ARIES-CS. Particles are launched uniformly over the s=0.3 flux surface with the pitch v_par/v drawn uniformly in [-1, 1], and traced until they reach the boundary (s=1) or the elapsed time is 1e-5 seconds.
 
-On perlmutter (04.20.26), the wallclock time is about 30 seconds using the attached slurm script. 
+coils.curves_22_7_21 holds the stellarator-symmetric half of a full-torus 40-coil set, so only stellsym is applied to it.
+
+On perlmutter (04.20.26), the wallclock time is about 30 seconds using the attached slurm script.

--- a/examples/gpu_cartesian_tracing/gpu_cartesian_tracing.py
+++ b/examples/gpu_cartesian_tracing/gpu_cartesian_tracing.py
@@ -37,7 +37,9 @@ for _i, coil in enumerate(coils):
     curves.append(coil.curve)
     currents.append(coil.current)
 
-coils_full = coils_via_symmetries(curves, currents, surf.nfp, True)
+# coils.curves_22_7_21 holds the stellarator-symmetric half of a full-torus
+# 40-coil set, so only stellsym is applied here.
+coils_full = coils_via_symmetries(curves, currents, 1, True)
 bs = BiotSavart(coils_full)
 
 surf_launch = SurfaceRZFourier.from_wout(wout_filename, s=0.3)

--- a/tests/field/test_gpu.py
+++ b/tests/field/test_gpu.py
@@ -139,7 +139,9 @@ def build_cartesian_field():
         curves.append(coil.curve)
         currents.append(coil.current)
 
-    coils_full = coils_via_symmetries(curves, currents, surf.nfp, True)
+    # coils.curves_22_7_21 holds the stellarator-symmetric half of a full-torus
+    # 40-coil set, so only stellsym is applied here.
+    coils_full = coils_via_symmetries(curves, currents, 1, True)
     bs = BiotSavart(coils_full)
 
     sc_particle = SurfaceClassifier(surf, h=0.1, p=2)


### PR DESCRIPTION
`examples/inputs/coils.curves_22_7_21` holds 20 coils: the stellarator-symmetric half of a full-torus 40-coil set. Both GPU Cartesian examples, and `build_cartesian_field` in `tests/field/test_gpu.py` which loads the same file, passed `surf.nfp` to `coils_via_symmetries`, replicating an already complete set four times.

Mean |B| on the LCFS of `wout_aten_rescaled.nc`:

| construction | ncoils | mean \|B\| |
|---|---|---|
| `coils_via_symmetries(surf.nfp, True)` | 160 | 23.764 T |
| `coils_via_symmetries(1, True)` | 40 | 5.941 T |
| equilibrium | | 5.941 T |

A 4x field means a 4x smaller gyroradius and much better alpha confinement, so this only ever showed up as suspiciously good confinement. A repo-wide grep found no other call sites.

Reference numbers regenerated on one A100. The collisional example goes to 10000 particles so its loss fraction is not two events:

| | before | after |
|---|---|---|
| Particles lost | 0.2% | 0.88% |
| Energy loss | 0.1% | 0.50% |
| Retained energy | ~24% | ~24% |

The retained energy is unchanged because the collision profiles set it rather than |B| — which, together with a loss fraction of two events in 1000, is why the error went unnoticed.

The collisional READMEs no longer claim the Cartesian example agrees with the two Boozer ones: it traces the field of a coil set rather than the equilibrium field, and alpha losses are sensitive to the difference, so they are not expected to match. The Boozer examples themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
