### PR TITLE
Review PRs on open and on request, not on every push

### DIFF
--- a/.github/workflows/cursor-code-review.yml
+++ b/.github/workflows/cursor-code-review.yml
@@ -1,14 +1,13 @@
 name: Code Review
 
-# Reviews once when a PR is opened. Every push used to re-review the whole
-# diff, which meant ~7 full model runs per PR re-flagging the same lines; add
-# the "Code Review" label to request a fresh look after addressing comments.
+# Reviews once when a PR is opened. Add the "Code Review" label to
+# request a fresh look after addressing comments.
 on:
   pull_request:
     types: [opened, reopened, ready_for_review, labeled]
 
 # Guards against reopen/relabel churn, and stops a hung run from occupying the
-# PR indefinitely the way a 145-minute run once did.
+# PR indefinitely.
 concurrency:
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/cursor-code-review.yml
+++ b/.github/workflows/cursor-code-review.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Only review the latest commit on a PR. Pushing again cancels the in-flight
+# review instead of paying for a full model run on a diff that is already stale.
+concurrency:
+  group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   pull-requests: write
   contents: read

--- a/.github/workflows/cursor-code-review.yml
+++ b/.github/workflows/cursor-code-review.yml
@@ -1,11 +1,14 @@
 name: Code Review
 
+# Reviews once when a PR is opened. Every push used to re-review the whole
+# diff, which meant ~7 full model runs per PR re-flagging the same lines; add
+# the "Code Review" label to request a fresh look after addressing comments.
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review, labeled]
 
-# Only review the latest commit on a PR. Pushing again cancels the in-flight
-# review instead of paying for a full model run on a diff that is already stale.
+# Guards against reopen/relabel churn, and stops a hung run from occupying the
+# PR indefinitely the way a 145-minute run once did.
 concurrency:
   group: ${{ github.workflow }}-pr-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -18,8 +21,12 @@ permissions:
 jobs:
   code-review:
     runs-on: ubuntu-latest
-    # Skip automated code review for draft PRs
-    if: github.event.pull_request.draft == false
+    # Skip drafts. Adding any other label must not trigger a review, so a
+    # labeled event only counts when the label is the one we gate on.
+    if: >
+      github.event.pull_request.draft == false &&
+      (github.event.action != 'labeled' ||
+       github.event.label.name == 'Code Review')
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The Cursor-backed Code Review workflow exhausted its model quota on 2026-08-07. Every run since has failed with `ActionRequiredError: You've hit your usage limit`, so the last 55 PRs have carried a red X unrelated to their code. The quota resets 8/27.

## Where the spend went

Measured over all Code Review runs before 2026-08-01:

| | |
|---|---|
| Successful reviews | 116, across 16 distinct PR branches |
| Reviews per PR | ~7.2 |
| Median run duration | 2.0 min |
| Runs a newer push overtook mid-flight | 4 of 145 (2%) |

The driver is volume, not overlapping runs. The workflow triggered on `synchronize`, so every push re-read the whole diff from scratch — roughly 100 of the 116 runs were re-reviews. Worst cases were `equilibrium_map` (35 reviews) and `perlmutter-ci` / `gpu_cartesian` (18 each).

Those re-reviews largely repeated themselves. On #51, `src/firm3dpp/ode_solvers.h:527` was flagged seven separate times across 44 reviews and 75 inline comments. The prompt already tells the agent to skip duplicates, but each run starts with no memory of the last.

## Changes

**Drop `synchronize`; add `labeled`.** Reviews run when a PR is opened, reopened, or marked ready. To request a fresh look after addressing comments, add the `Code Review` label — the same pattern `cuda-ci.yml` and `perlmutter-ci.yml` already use with `NVIDIA CI` and `GPU CI`.

`labeled` fires for *any* label, so the job-level `if` gates on the label name; otherwise adding `bug` would spend a review. `github.event.label` is null on the other event types, and `null == 'Code Review'` is false, so the `action != 'labeled'` clause carries them.

**Scope `concurrency` to the PR.** Worth only ~2% on its own given the 2-minute median, but it caps the tail — one failed run previously sat for 145 minutes.

Projected effect: ~116 automatic runs over that window become ~16, plus whatever is explicitly requested.

## Requires

The `Code Review` label now exists on this repo. Without it there is no way to request a re-review and each PR gets exactly one.

## Tradeoff

Objective 1 in the agent prompt — re-checking existing comments and marking them resolved — now happens only on request rather than automatically on each push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Reduce Cursor-backed code review usage by reviewing pull requests on key lifecycle events and explicit `Code Review` requests instead of every push.

New Features:
- Allow pull-request reviews to be requested explicitly by applying the `Code Review` label.

Bug Fixes:
- Prevent unrelated labels from triggering code reviews.
- Cancel superseded or hung reviews for the same pull request.

Enhancements:
- Reduce redundant automatic reviews by limiting triggers to pull-request lifecycle events and explicit review requests.