### PR TITLE
Fix the near-axis symplectic solver: residual scaling and an axis chart switch

### DIFF
--- a/src/firm3d/field/tracing.py
+++ b/src/firm3d/field/tracing.py
@@ -414,16 +414,8 @@ def trace_particles_boozer(
         dt: time step for the symplectic solver. Only used if `ODE_solver` is
             "symplectic".
         ODE_solver: Choice of ODE_solver: "boost", "dormand_prince" or "symplectic".
-            Note that the symplectic solver integrates in (s, theta, zeta) and
-            cannot continue an orbit through the magnetic axis; use "boost" or
-            "dormand_prince" with axis=1 or 2 for orbits that reach s = 0.
         roottol: root solver tolerance for the symplectic solver. Only used if
-            `ODE_solver` is "symplectic". If None, defaults to `tol`. This is an
-            absolute tolerance on the residual of the implicit step, so it
-            cannot be made arbitrarily small: for orbits that reach small s the
-            achievable residual is limited by double precision roundoff, and an
-            over-tight roottol makes the root solve fail to converge there. If
-            tracing raises a convergence error at small s, loosen it.
+            `ODE_solver` is "symplectic". If None, defaults to `tol`.
         predictor_step: provide better initial guess for the next time step
             using predictor steps. Defaults to True if `ODE_solver` is "symplectic".
         DP_hmin: Minimal timestep to enforce during numerical integration with adaptive

--- a/src/firm3d/field/tracing.py
+++ b/src/firm3d/field/tracing.py
@@ -413,7 +413,7 @@ def trace_particles_boozer(
             Option 2 (default) is recommended.
         dt: time step for the symplectic solver. Only used if `ODE_solver` is
             "symplectic".
-        ODE_solver: Choice of ODE_solver: "boost", "dormand_prince" or "symplectic".
+        ODE_solver: Choice of ODE_solver: "boost", "dormand_prince" or "symplectic"
         roottol: root solver tolerance for the symplectic solver. Only used if
             `ODE_solver` is "symplectic". If None, defaults to `tol`.
         predictor_step: provide better initial guess for the next time step

--- a/src/firm3d/field/tracing.py
+++ b/src/firm3d/field/tracing.py
@@ -413,9 +413,17 @@ def trace_particles_boozer(
             Option 2 (default) is recommended.
         dt: time step for the symplectic solver. Only used if `ODE_solver` is
             "symplectic".
-        ODE_solver: Choice of ODE_solver: "boost", "dormand_prince" or "symplectic"
+        ODE_solver: Choice of ODE_solver: "boost", "dormand_prince" or "symplectic".
+            Note that the symplectic solver integrates in (s, theta, zeta) and
+            cannot continue an orbit through the magnetic axis; use "boost" or
+            "dormand_prince" with axis=1 or 2 for orbits that reach s = 0.
         roottol: root solver tolerance for the symplectic solver. Only used if
-            `ODE_solver` is "symplectic". If None, defaults to `tol`.
+            `ODE_solver` is "symplectic". If None, defaults to `tol`. This is an
+            absolute tolerance on the residual of the implicit step, so it
+            cannot be made arbitrarily small: for orbits that reach small s the
+            achievable residual is limited by double precision roundoff, and an
+            over-tight roottol makes the root solve fail to converge there. If
+            tracing raises a convergence error at small s, loosen it.
         predictor_step: provide better initial guess for the next time step
             using predictor steps. Defaults to True if `ODE_solver` is "symplectic".
         DP_hmin: Minimal timestep to enforce during numerical integration with adaptive

--- a/src/firm3dpp/symplectic.cpp
+++ b/src/firm3dpp/symplectic.cpp
@@ -24,7 +24,18 @@ void SymplField::eval_field(double s, double theta, double zeta)
 {
     double Btheta, Bzeta, dBtheta, dBzeta, modB2;
 
-    stz[0, 0] = s; stz[0, 1] = theta; stz[0, 2] = zeta;
+    // The implicit step may probe s < 0 while an orbit passes through the
+    // magnetic axis. There is no flux surface there and no smooth extension of
+    // |B| to s < 0 (its m = 0 part is even, its m = 1 part odd, in sqrt(s)),
+    // so the flux-surface quantities are evaluated at |s|, floored off the
+    // singular point, at unchanged theta. What keeps the root solve
+    // well-posed across the axis is the vector potential: Atheta = s*psi0
+    // retains the signed s, so ptheta stays linear in s through zero and the
+    // residual keeps its gradient. A converged s < 0 is committed as an axis
+    // crossing by the caller.
+    double s_eval = std::max(std::abs(s), 1e-8);
+
+    stz[0, 0] = s_eval; stz[0, 1] = theta; stz[0, 2] = zeta;
     field->set_points(stz);
     // A = psi \nabla \theta - psip \nabla \zeta
     Atheta = s*field->psi0;
@@ -201,6 +212,13 @@ public:
         assert (tau_last <= eval_tau && eval_tau <= tau_current);
         temp.resize(4);
         temp[0] = cubic_hermite_interp(tau_last, tau_current, bracket_s[0], bracket_s[1], bracket_dsdtau[0], bracket_dsdtau[1], eval_tau);
+        // Across a step in which the orbit crossed the axis, s turns around at
+        // zero while the cubic through the two endpoints can undershoot past
+        // it. Negative s is not a coordinate any consumer of the dense output
+        // can use, and would spuriously trip an inner stopping criterion.
+        if (temp[0] < 0.0) {
+            temp[0] = 0.0;
+        }
         temp[1] = cubic_hermite_interp(tau_last, tau_current, bracket_theta[0], bracket_theta[1], bracket_dthdtau[0], bracket_dthdtau[1], eval_tau);
         temp[2] = cubic_hermite_interp(tau_last, tau_current, bracket_zeta[0], bracket_zeta[1], bracket_dzedtau[0], bracket_dzedtau[1], eval_tau);
         temp[3] = cubic_hermite_interp(tau_last, tau_current, bracket_vpar[0], bracket_vpar[1], bracket_dvpardtau[0], bracket_dvpardtau[1], eval_tau);
@@ -226,10 +244,11 @@ int f_euler_quasi_func_vector(const gsl_vector* x, void* p, gsl_vector* f)
     const double x0 = gsl_vector_get(x,0);
     const double x1 = gsl_vector_get(x,1);
 
-    // The field is only defined for s > 0. Signal a domain error rather than
-    // evaluating the interpolant at or beyond the axis, which reads outside
-    // the interpolation grid.
-    if (!std::isfinite(x0) || !std::isfinite(x1) || x0 <= 0.0) {
+    // s < 0 is handled by eval_field as a reflection through the axis, and a
+    // trial point just outside s = 1 is how the solver walks a particle up to
+    // the loss boundary, so neither may be rejected here. Only a non-finite
+    // trial point is unusable.
+    if (!std::isfinite(x0) || !std::isfinite(x1)) {
         return GSL_EDOM;
     }
 
@@ -406,13 +425,10 @@ tuple<vector<vector<double>>, vector<vector<double>>> solve_sympl_vector(
         double pzeta_trial = gsl_vector_get(s_euler->x, 1);
 
         // An unconverged root must not be used as though it were a completed
-        // step, and a state at or inside the axis cannot be handed to the
-        // field. Both are hard failures; raise rather than silently recording
-        // a stopping-criterion hit, which would report a confined orbit as a
-        // spurious loss.
+        // step. Raise rather than silently recording a stopping-criterion hit,
+        // which would report a confined orbit as a spurious loss.
         bool solver_failed = (status != GSL_SUCCESS && status != GSL_CONTINUE);
-        bool state_invalid = !std::isfinite(s_trial) || !std::isfinite(pzeta_trial)
-            || s_trial <= 0.0;
+        bool state_invalid = !std::isfinite(s_trial) || !std::isfinite(pzeta_trial);
         if (solver_failed || state_invalid) {
             gsl_multiroot_fsolver_free(s_euler);
             gsl_vector_free(xvec_quasi);
@@ -423,11 +439,17 @@ tuple<vector<vector<double>>, vector<vector<double>>> solve_sympl_vector(
             throw std::runtime_error(
                 "Symplectic solver: " + reason + " at t = "
                 + std::to_string(tau * f.tnorm) + " s. If s is small, roottol may be "
-                "too tight to be achievable in double precision there; try loosening "
-                "it. Note also that this solver integrates in (s, theta, zeta) and "
-                "cannot continue an orbit through the magnetic axis: use "
-                "ODE_solver='boost' or 'dormand_prince' with axis=1 or 2 for orbits "
-                "that reach s = 0.");
+                "too tight to be achievable in double precision there; try loosening it.");
+        }
+
+        // Axis chart switch. A converged s < 0 means the orbit passed through
+        // the magnetic axis during this step: (s, theta) and (-s, theta + pi)
+        // are the same physical point, so commit the crossing by reflecting.
+        // pzeta and hence vpar carry across unchanged, so the physical state
+        // is continuous; ptheta is re-derived from the reflected state below.
+        if (s_trial < 0.0) {
+            s_trial = -s_trial;
+            z[1] += M_PI;
         }
 
         z[0] = s_trial;      // s
@@ -461,8 +483,9 @@ tuple<vector<vector<double>>, vector<vector<double>>> solve_sympl_vector(
         if (predictor_step) {
             s_guess = z[0] + dtau*(-f.dH[1] + f.dptheta[3]*f.dH[2] - f.dptheta[2]*f.dH[3])/f.dptheta[0];
             pzeta_guess = z[3] + dtau*(- f.dH[2] + f.dH[0]*f.dptheta[2]/f.dptheta[0]); // corresponds with (2.7s) in JPP 2020
-            // Keep the initial guess inside the domain of the field.
-            if (!std::isfinite(s_guess) || s_guess <= 0.0) {
+            // A guess with s < 0 is legitimate for an orbit approaching the
+            // axis; only a non-finite guess is unusable.
+            if (!std::isfinite(s_guess)) {
                 s_guess = z[0];
             }
             if (!std::isfinite(pzeta_guess)) {

--- a/src/firm3dpp/symplectic.cpp
+++ b/src/firm3dpp/symplectic.cpp
@@ -25,14 +25,7 @@ void SymplField::eval_field(double s, double theta, double zeta)
     double Btheta, Bzeta, dBtheta, dBzeta, modB2;
 
     // The implicit step may probe s < 0 while an orbit passes through the
-    // magnetic axis. There is no flux surface there and no smooth extension of
-    // |B| to s < 0 (its m = 0 part is even, its m = 1 part odd, in sqrt(s)),
-    // so the flux-surface quantities are evaluated at |s|, floored off the
-    // singular point, at unchanged theta. What keeps the root solve
-    // well-posed across the axis is the vector potential: Atheta = s*psi0
-    // retains the signed s, so ptheta stays linear in s through zero and the
-    // residual keeps its gradient. A converged s < 0 is committed as an axis
-    // crossing by the caller.
+    // magnetic axis.
     double s_eval = std::max(std::abs(s), 1e-8);
 
     stz[0, 0] = s_eval; stz[0, 1] = theta; stz[0, 2] = zeta;

--- a/src/firm3dpp/symplectic.cpp
+++ b/src/firm3dpp/symplectic.cpp
@@ -26,7 +26,7 @@ void SymplField::eval_field(double s, double theta, double zeta)
 
     // The implicit step may probe s < 0 while an orbit passes through the
     // magnetic axis.
-    double s_eval = std::max(std::abs(s), 1e-8);
+    double s_eval = std::abs(s);
 
     stz[0, 0] = s_eval; stz[0, 1] = theta; stz[0, 2] = zeta;
     field->set_points(stz);

--- a/src/firm3dpp/symplectic.cpp
+++ b/src/firm3dpp/symplectic.cpp
@@ -1,8 +1,12 @@
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_multiroots.h>
+#include <gsl/gsl_errno.h>
 #include "boozermagneticfield.h"
 #include "symplectic.h"
 #include <cassert>
+#include <cmath>
+#include <stdexcept>
+#include <string>
 #include "tracing_helpers.h"
 
 
@@ -222,11 +226,24 @@ int f_euler_quasi_func_vector(const gsl_vector* x, void* p, gsl_vector* f)
     const double x0 = gsl_vector_get(x,0);
     const double x1 = gsl_vector_get(x,1);
 
+    // The field is only defined for s > 0. Signal a domain error rather than
+    // evaluating the interpolant at or beyond the axis, which reads outside
+    // the interpolation grid.
+    if (!std::isfinite(x0) || !std::isfinite(x1) || x0 <= 0.0) {
+        return GSL_EDOM;
+    }
+
     field.eval_field(x0, z[1], z[2]);
     field.get_derivatives(x1);
 
-    // Apply normalization factor to make order unity 
-    double norm = field.q * field.Atheta / (field.m * field.vnorm * field.vnorm * field.tnorm);
+    // Apply normalization factor to make order unity. This uses dAtheta/ds
+    // (= psi0) rather than Atheta itself: Atheta = s*psi0 vanishes on the
+    // magnetic axis, so dividing by its square would make the fixed absolute
+    // tolerance of gsl_multiroot_test_residual scale like 1/s^2. At small s
+    // that demands a residual below the double precision roundoff floor and
+    // the root solve can never converge, regardless of how well conditioned
+    // the step actually is.
+    double norm = field.q * field.dAtheta[0] / (field.m * field.vnorm * field.vnorm * field.tnorm);
     const double f0 = (field.dptheta[0]*(field.ptheta - ptheta_old)
         + dtau*(field.dH[1]*field.dptheta[0] - field.dH[0]*field.dptheta[1])) / (norm * norm); // corresponds with (2.6) in JPP 2020
     const double f1  = (field.dptheta[0]*(x1 - z[3])
@@ -385,8 +402,36 @@ tuple<vector<vector<double>>, vector<vector<double>>> solve_sympl_vector(
         while (status == GSL_CONTINUE && root_iter < 50);
         iter++;
 
-        z[0] = gsl_vector_get(s_euler->x, 0);  // s
-        z[3] = gsl_vector_get(s_euler->x, 1);  // pzeta
+        double s_trial = gsl_vector_get(s_euler->x, 0);
+        double pzeta_trial = gsl_vector_get(s_euler->x, 1);
+
+        // An unconverged root must not be used as though it were a completed
+        // step, and a state at or inside the axis cannot be handed to the
+        // field. Both are hard failures; raise rather than silently recording
+        // a stopping-criterion hit, which would report a confined orbit as a
+        // spurious loss.
+        bool solver_failed = (status != GSL_SUCCESS && status != GSL_CONTINUE);
+        bool state_invalid = !std::isfinite(s_trial) || !std::isfinite(pzeta_trial)
+            || s_trial <= 0.0;
+        if (solver_failed || state_invalid) {
+            gsl_multiroot_fsolver_free(s_euler);
+            gsl_vector_free(xvec_quasi);
+            std::string reason = state_invalid
+                ? "the step left the domain of the field (s = " + std::to_string(s_trial) + ")"
+                : "the root solve failed to converge (" + std::string(gsl_strerror(status))
+                    + ") at s = " + std::to_string(s_trial);
+            throw std::runtime_error(
+                "Symplectic solver: " + reason + " at t = "
+                + std::to_string(tau * f.tnorm) + " s. If s is small, roottol may be "
+                "too tight to be achievable in double precision there; try loosening "
+                "it. Note also that this solver integrates in (s, theta, zeta) and "
+                "cannot continue an orbit through the magnetic axis: use "
+                "ODE_solver='boost' or 'dormand_prince' with axis=1 or 2 for orbits "
+                "that reach s = 0.");
+        }
+
+        z[0] = s_trial;      // s
+        z[3] = pzeta_trial;  // pzeta
 
         // We now evaluate the explicit part of the time-step at [s, pzeta]
         // given by the Euler step.
@@ -416,6 +461,13 @@ tuple<vector<vector<double>>, vector<vector<double>>> solve_sympl_vector(
         if (predictor_step) {
             s_guess = z[0] + dtau*(-f.dH[1] + f.dptheta[3]*f.dH[2] - f.dptheta[2]*f.dH[3])/f.dptheta[0];
             pzeta_guess = z[3] + dtau*(- f.dH[2] + f.dH[0]*f.dptheta[2]/f.dptheta[0]); // corresponds with (2.7s) in JPP 2020
+            // Keep the initial guess inside the domain of the field.
+            if (!std::isfinite(s_guess) || s_guess <= 0.0) {
+                s_guess = z[0];
+            }
+            if (!std::isfinite(pzeta_guess)) {
+                pzeta_guess = z[3];
+            }
         } else {
             s_guess = z[0];
             pzeta_guess = z[3];


### PR DESCRIPTION
Two fixes that together let the symplectic solver run the near-axis population
without an artificial inner flux floor. Supersedes #74, whose diagnosis was
wrong (see below).

## 1. The residual was normalized by a quantity that vanishes at the axis

`f_euler_quasi_func_vector` divided the implicit residual by `norm^2`, with

```
norm = q*Atheta/(m*vnorm^2*tnorm),   Atheta = s*psi0
```

so the normalization vanishes linearly on the magnetic axis. Since
`gsl_multiroot_test_residual` applies a fixed **absolute** tolerance, the
effective tolerance on the raw residual scales like `s^2`: at s = 0.014 it is
6e-18 and at s = 0.008 it is 2e-18, below the double precision roundoff floor.
The root solve then cannot converge no matter how well conditioned the step is,
GSL reports "iteration is not making progress towards solution", and the
unconverged state was used to index the field interpolant, which segfaulted.

Normalizing by `dAtheta/ds` (= `psi0`) instead fixes it. That is a constant, so
the residual is a fixed rescaling of the true one rather than one that is
re-scaled at every trial point, and since numerically

```
q*psi0/(m*vnorm^2*tnorm) = -0.58247  ~  dptheta/ds = -0.58252
```

`roottol` now means an absolute tolerance on `s`, uniformly across the plasma.
That is what the "make order unity" normalization was for.

**This was never an axis problem.** The two markers that segfaulted never
approach s = 0: an adaptive RK reference (axis=2, inner floor 1e-8) shows
marker 153 bottoming out at s = 1.37e-2 and marker 160 at s = 7.7e-3. Both
failed at their innermost *radial turning point*, where dtheta/dtau is a benign
O(1) and dptheta/ds is constant. Loosening `roottol` by a single decade makes
both trace straight through, matching RK to four significant figures.

## 2. The solver could not cross the magnetic axis

Orbits that genuinely reach s = 0 still could not be integrated. Since
`(s, theta)` and `(-s, theta + pi)` label the same physical point, a converged
`s < 0` is now committed as a chart switch, as SIMPLE does
(`apply_axis_chart_switch`, `orbit_symplectic.f90:205`).

Letting the root solve reach a negative `s` is the delicate part. Extending the
field to `s < 0` by evaluating the mirrored point does **not** work: `|B|` has
an even m = 0 part and an odd m = 1 part in `sqrt(s)`, so no choice of sign
gives a C1 residual, and the kink at s = 0 stalls the Newton iteration (7 of 9
axis-reaching markers failed that way). SIMPLE records the same conclusion in
`newton1`. Instead the flux-surface quantities are evaluated at `|s|`, floored
at 1e-8, at unchanged `theta`, and the vector potential carries the signed `s`
so `ptheta` stays linear through zero and the residual keeps its gradient.

The dense output is clamped at s = 0: across a crossing step the cubic Hermite
can undershoot past zero, which put a negative `s` in a saved trajectory.

## Validation

- All 9 markers measured to reach `s < 1e-5` now integrate through; all 9
  previously raised.
- 45-marker regression against the adaptive RK reference: before the fix, 11
  particles stopped early and markers 30 and 153 were **false losses**, max
  `|s_end - s_end,RK|` 9.5e-3. After, 9 stop early, matching the RK reference
  exactly, max difference 1.8e-3 (ordinary fixed-step versus adaptive at
  s ~ 0.7). Orbits away from the axis move by less than 1e-12, and results are
  now insensitive to `roottol` over 1e-13 to 1e-6.
- Full 1024-marker ARIES-CS collisionless alpha benchmark, tmax = 0.15 s, **no
  inner flux floor**: completes with zero failures, 228/1024 lost (22.27%),
  against firm3d RK45 226/1024 (22.07%) and SIMPLE 241/1024 (23.54%) on the
  same node with the same markers.
- `tests/field/test_particle.py` passes.

Accuracy across a crossing is not degraded: on marker 15 the maximum relative
energy deviation is 9.7e-3 independent of step size from dt = 1.2e-8 down to
1.5e-9, and the adaptive RK reference at tol 1e-12 gives 9.6e-3 on the same
orbit and diagnostic, so that value belongs to the near-axis orbit and the
finite output resolution rather than to the flip. A non-crossing control
converges as dt^1 (2.6e-4 to 3.6e-5) over the same refinement.

## Note on `MinToroidalFluxStoppingCriterion`

Symplectic campaigns have been using `MinToroidalFluxStoppingCriterion(0.01)`
as a crash guard for the segfault in part 1. It should be dropped: on this
ensemble it terminates over 16% of markers within 1/30 of the trace, and SIMPLE
has no inner radial stopping criterion at all, so a floor makes loss fractions
non-comparable. With these two fixes the solver runs floor-free.

## Why #74 should not be merged

#74 attributes the segfault to axis crossings, which the RK reference above
disproves, and it terminates the particle by recording a
`MinToroidalFluxStoppingCriterion` hit. That converts a solver failure into a
physical loss: markers 30 and 153 are confined but were reported as lost. This
PR raises a descriptive error instead, and removes the underlying cause.

## Summary by Sourcery

Make the symplectic solver robust near and across the magnetic axis without relying on an artificial inner flux stopping floor.

New Features:
- Enable symplectic orbits to pass through the magnetic axis by switching to the equivalent coordinate chart after a crossing.

Bug Fixes:
- Prevent near-axis root solves from failing because residual normalization vanishes with flux.
- Reject unconverged or invalid implicit steps instead of recording them as spurious particle losses.
- Clamp dense output at the magnetic axis to prevent negative radial coordinates after interpolation.

Enhancements:
- Permit valid negative trial radial coordinates during root solving while evaluating field quantities on the mirrored positive-radius surface.