### PR TITLE
Adding phase to SAW, passing mu instead of total veloctiy 

### DIFF
--- a/src/firm3d/catapult/tracing.py
+++ b/src/firm3d/catapult/tracing.py
@@ -1,4 +1,8 @@
-__all__ = ["trace_particles_boozer_gpu", "trace_particles_cartesian_gpu"]
+__all__ = [
+    "trace_particles_boozer_gpu",
+    "trace_particles_boozer_perturbed_gpu",
+    "trace_particles_cartesian_gpu",
+]
 import numpy as np
 
 import firm3dpp
@@ -32,80 +36,31 @@ def trace_particles_boozer_gpu(
     tmax: maximum time to trace particles
     mass: mass of each particle
     charge: charge of each particle
-    vtotal: total velocity of each particle
+    vtotal: initial total speed shared by all particles, in m/s
     tol: tolerance for the ODE solver
     dt: the initial time step size for the solver (optional)
+
+    For perturbed fields, this preserves the monoenergetic calling convention
+    by converting vtotal to Ekin. Use trace_particles_boozer_perturbed_gpu
+    directly to supply initial energies in Joules, including an energy array.
     """
     nparticles = stz_inits.shape[0]
 
     if isinstance(field, ShearAlfvenWavesSuperposition):
-        B0 = field.B0
-        srange, trange, zrange, quad_info, maxJ = boozer_saw_interpolant(
-            B0, B0.nfp, ns, ntheta, nzeta
+        return trace_particles_boozer_perturbed_gpu(
+            field,
+            stz_inits,
+            parallel_speeds,
+            Ekin=0.5 * mass * vtotal**2,
+            tmax=tmax,
+            mass=mass,
+            charge=charge,
+            tol=tol,
+            ns=ns,
+            ntheta=ntheta,
+            nzeta=nzeta,
+            dt=dt,
         )
-        saw_nharmonics = len(field)
-        saw_omega = field.get_wave(0).omega
-        saw_s = field.get_wave(0).phihat.get_s_basis()
-        saw_srange = (saw_s[0], saw_s[-1], len(saw_s))
-        saw_m = [field.get_wave(i).Phim for i in range(saw_nharmonics)]
-        saw_n = [field.get_wave(i).Phin for i in range(saw_nharmonics)]
-        saw_phihats = np.ascontiguousarray(
-            np.column_stack(
-                [
-                    np.array([field.get_wave(i).phihat(s_val) for s_val in saw_s])
-                    for i in range(saw_nharmonics)
-                ]
-            )
-        )
-
-        if B0.field_type == "vac":
-            last_time = firm3dpp.boozer_saw_gpu_tracing(
-                quad_pts=quad_info,
-                srange=srange,
-                trange=trange,
-                zrange=zrange,
-                saw_omega=saw_omega,
-                saw_srange=saw_srange,
-                saw_m=saw_m,
-                saw_n=saw_n,
-                saw_phihats=saw_phihats,
-                saw_nharmonics=saw_nharmonics,
-                stz_init=stz_inits,
-                m=mass,
-                q=charge,
-                vtotal=vtotal,
-                vtang=parallel_speeds,
-                tmax=tmax,
-                tol=tol,
-                dt_in=dt if dt is not None else -np.ones(nparticles),
-                psi0=B0.psi0,
-                nparticles=nparticles,
-            )
-        elif B0.field_type == "nok":
-            last_time = firm3dpp.boozer_saw_nok_gpu_tracing(
-                quad_pts=quad_info,
-                srange=srange,
-                trange=trange,
-                zrange=zrange,
-                saw_omega=saw_omega,
-                saw_srange=saw_srange,
-                saw_m=saw_m,
-                saw_n=saw_n,
-                saw_phihats=saw_phihats,
-                saw_nharmonics=saw_nharmonics,
-                stz_init=stz_inits,
-                m=mass,
-                q=charge,
-                vtotal=vtotal,
-                vtang=parallel_speeds,
-                tmax=tmax,
-                tol=tol,
-                dt_in=dt if dt is not None else -np.ones(nparticles),
-                psi0=B0.psi0,
-                nparticles=nparticles,
-            )
-        else:
-            raise ValueError(f"Unsupported field type {B0.field_type} for SAW tracing")
     else:
         if field.field_type not in ["vac", ""]:
             raise ValueError(
@@ -137,6 +92,132 @@ def trace_particles_boozer_gpu(
 
     last_time = np.reshape(last_time, (nparticles, 6))
     return last_time
+
+
+def trace_particles_boozer_perturbed_gpu(
+    field,
+    stz_inits,
+    parallel_speeds,
+    Ekin,
+    tmax,
+    mass,
+    charge,
+    tol,
+    ns,
+    ntheta,
+    nzeta,
+    dt=None,
+):
+    """Trace particles in a SAW field from their initial kinetic energies.
+
+    field: ShearAlfvenWavesSuperposition with a vacuum or no-K background
+    stz_inits: finite (N, 3) launch coordinates (s, theta, zeta), with N > 0
+    parallel_speeds: finite (N,) initial parallel velocities in m/s
+    Ekin: nonnegative initial kinetic energy in Joules, a scalar or (N,) array
+    tmax: maximum tracing time in seconds
+    mass: positive particle mass in kg, shared by the particles
+    charge: particle charge in Coulombs, shared by the particles
+    tol: tolerance for the ODE solver
+    ns, ntheta, nzeta: numbers of interpolation cells in each direction
+    dt: optional (N,) array of initial timesteps in seconds
+
+    The wrapper computes mu = (2*Ekin/mass - v_parallel**2)/(2*|B0|)
+    at the launch points and passes it to C++ as a fixed moment per unit mass,
+    in m^2/(s^2 T), clipping negative values to zero.
+    The maximum initial speed is passed as the numerical reference vtotal for
+    timestep and tolerance scaling and must be positive.
+
+    Returns an (N, 6) array with columns [time, s, theta, zeta, v_parallel, dt].
+    """
+    if not isinstance(field, ShearAlfvenWavesSuperposition):
+        raise ValueError("field must be a ShearAlfvenWavesSuperposition")
+    B0 = field.B0
+    if B0.field_type not in ["vac", "nok"]:
+        raise ValueError(f"Unsupported field type {B0.field_type} for SAW tracing")
+
+    # C++ overwrites the coordinates; copy them to preserve the caller's input.
+    points = np.array(stz_inits, dtype=np.float64, order="C", copy=True)
+    vpar = np.ascontiguousarray(parallel_speeds, dtype=np.float64)
+    energy = np.asarray(Ekin, dtype=np.float64)
+    if points.ndim != 2 or points.shape[1] != 3:
+        raise ValueError("stz_inits must have shape (N, 3)")
+    nparticles = points.shape[0]
+    if nparticles == 0 or vpar.shape != (nparticles,):
+        raise ValueError("parallel_speeds must have shape (N,), with N > 0")
+    if energy.ndim == 0:
+        energy = np.full(nparticles, energy.item(), dtype=np.float64)
+    elif energy.shape != (nparticles,):
+        raise ValueError("Ekin must be a scalar or have shape (N,)")
+    if not np.isfinite(energy).all() or np.any(energy < 0):
+        raise ValueError("Ekin must be finite and nonnegative")
+
+    speed2 = 2.0 * energy / mass
+    vperp2 = speed2 - vpar**2
+    if not np.isfinite(speed2).all() or not np.isfinite(vperp2).all():
+        raise ValueError("initial squared speeds must be finite")
+    vperp2 = np.maximum(vperp2, 0.0)
+
+    B0.set_points(points)
+    B_init = np.array(B0.modB()[:, 0], dtype=np.float64, copy=True)
+    if (
+        B_init.shape != (nparticles,)
+        or not np.isfinite(B_init).all()
+        or np.any(B_init <= 0)
+    ):
+        raise ValueError("initial background |B| must be finite and positive")
+    mus = np.ascontiguousarray(vperp2 / (2.0 * B_init))
+    if not np.isfinite(mus).all():
+        raise ValueError("computed mus must be finite")
+    speed2_max = np.max(speed2)
+    if speed2_max <= 0:
+        raise ValueError("max(speed2) must be positive to define v_reference")
+    v_reference = float(np.sqrt(speed2_max))
+
+    srange, trange, zrange, quad_info, maxJ = boozer_saw_interpolant(
+        B0, B0.nfp, ns, ntheta, nzeta
+    )
+    saw_nharmonics = len(field)
+    saw_omega = field.get_wave(0).omega
+    saw_s = field.get_wave(0).phihat.get_s_basis()
+    saw_srange = (saw_s[0], saw_s[-1], len(saw_s))
+    saw_m = [field.get_wave(i).Phim for i in range(saw_nharmonics)]
+    saw_n = [field.get_wave(i).Phin for i in range(saw_nharmonics)]
+    saw_phihats = np.ascontiguousarray(
+        np.column_stack(
+            [
+                np.array([field.get_wave(i).phihat(s_val) for s_val in saw_s])
+                for i in range(saw_nharmonics)
+            ]
+        )
+    )
+    if B0.field_type == "vac":
+        trace = firm3dpp.boozer_saw_gpu_tracing
+    else:
+        trace = firm3dpp.boozer_saw_nok_gpu_tracing
+    last_time = trace(
+        quad_pts=quad_info,
+        srange=srange,
+        trange=trange,
+        zrange=zrange,
+        saw_omega=saw_omega,
+        saw_srange=saw_srange,
+        saw_m=saw_m,
+        saw_n=saw_n,
+        saw_phihats=saw_phihats,
+        saw_nharmonics=saw_nharmonics,
+        stz_init=points,
+        m=mass,
+        q=charge,
+        vtotal=v_reference,
+        vtang=vpar,
+        mus=mus,
+        tmax=tmax,
+        tol=tol,
+        dt_in=dt if dt is not None else -np.ones(nparticles),
+        psi0=B0.psi0,
+        nparticles=nparticles,
+    )
+    return np.reshape(last_time, (nparticles, 6))
 
 
 def trace_particles_cartesian_gpu(

--- a/src/firm3d/catapult/tracing.py
+++ b/src/firm3d/catapult/tracing.py
@@ -182,6 +182,9 @@ def trace_particles_boozer_perturbed_gpu(
     saw_srange = (saw_s[0], saw_s[-1], len(saw_s))
     saw_m = [field.get_wave(i).Phim for i in range(saw_nharmonics)]
     saw_n = [field.get_wave(i).Phin for i in range(saw_nharmonics)]
+    saw_phases = np.ascontiguousarray(
+        [field.get_wave(i).phase for i in range(saw_nharmonics)], dtype=np.float64
+    )
     saw_phihats = np.ascontiguousarray(
         np.column_stack(
             [
@@ -204,6 +207,7 @@ def trace_particles_boozer_perturbed_gpu(
         saw_m=saw_m,
         saw_n=saw_n,
         saw_phihats=saw_phihats,
+        saw_phases=saw_phases,
         saw_nharmonics=saw_nharmonics,
         stz_init=points,
         m=mass,

--- a/src/firm3dpp/cuda_kernel.cu
+++ b/src/firm3dpp/cuda_kernel.cu
@@ -916,7 +916,7 @@ __global__ void particle_trace_kernel(double* out, double* init_pos, double* qua
         for(int i=0; i<4; ++i){
             state[i*PARTICLES_PER_BLOCK + threadIdx.x] = init_pos[4*idx + i];
         }
-        dt[threadIdx.x] = dt_in[threadIdx.x]; // copy input dt
+        dt[threadIdx.x] = dt_in[idx]; // copy input dt
         if(mus_init != nullptr){
             mu[threadIdx.x] = mus_init[idx];
         }
@@ -1056,6 +1056,7 @@ vector<double> gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> x1_
 
     gpuErrchk( cudaFree(quadpts_d) );
     gpuErrchk( cudaFree(init_pos_d) );
+    gpuErrchk( cudaFree(dt_in_d) );
     gpuErrchk( cudaFree(out_d) );
     vector<double> particle_output(6*nparticles);
     for(int i=0; i<6*nparticles; ++i){

--- a/src/firm3dpp/cuda_kernel.cu
+++ b/src/firm3dpp/cuda_kernel.cu
@@ -355,7 +355,7 @@ __device__ void calc_derivs<RHS::GC_Boozer>(double* derivs, int deriv_id, double
 template <> 
 __device__ void calc_derivs<RHS::GC_BoozerVacuumSAW>(double* derivs, int deriv_id, double* quadpts_arr, double* x_temp, bool* symmetry_exploited, 
                                     int* index_i, int* index_j, int* index_k, double* x1_shape, double* x2_shape, double* x3_shape,
-                                    double* mu, int nparticles_blk, double saw_omega, int* saw_m, int* saw_n, double* saw_phihats, int saw_nharmonics){
+                                    double* mu, int nparticles_blk, double saw_omega, int* saw_m, int* saw_n, double* saw_phihats, double* saw_phases, int saw_nharmonics){
    __shared__ double block_interpolants[10*PARTICLES_PER_BLOCK];
 
     __syncthreads();
@@ -414,8 +414,8 @@ __device__ void calc_derivs<RHS::GC_BoozerVacuumSAW>(double* derivs, int deriv_i
             double alpha_fac = (iota *m - n) / (saw_omega * G);
             double dalpha_fac_dpsi = diotadpsi * m / (saw_omega * G);
 
-            double pt_cos = cos(m*theta - n*zeta + saw_omega*time);
-            double pt_sin = sin(m*theta - n*zeta + saw_omega*time);
+            double pt_cos = cos(m*theta - n*zeta + saw_omega*time + saw_phases[i]);
+            double pt_sin = sin(m*theta - n*zeta + saw_omega*time + saw_phases[i]);
 
             double phihat_i = left_phihat + s_slope*(s_diff);
             double dphihatdpsi = s_slope / psi0_d;
@@ -464,7 +464,7 @@ __device__ void calc_derivs<RHS::GC_BoozerVacuumSAW>(double* derivs, int deriv_i
 template <> 
 __device__ void calc_derivs<RHS::GC_BoozerNoKSAW>(double* derivs, int deriv_id, double* quadpts_arr, double* x_temp, bool* symmetry_exploited, 
                                     int* index_i, int* index_j, int* index_k, double* x1_shape, double* x2_shape, double* x3_shape,
-                                    double* mu, int nparticles_blk, double saw_omega, int* saw_m, int* saw_n, double* saw_phihats, int saw_nharmonics){
+                                    double* mu, int nparticles_blk, double saw_omega, int* saw_m, int* saw_n, double* saw_phihats, double* saw_phases, int saw_nharmonics){
 
    __shared__ double block_interpolants[10*PARTICLES_PER_BLOCK];
 
@@ -527,8 +527,8 @@ __device__ void calc_derivs<RHS::GC_BoozerNoKSAW>(double* derivs, int deriv_id, 
             double alpha_fac = (iota *m - n) / (saw_omega * (G + iota*I));
             double dalpha_fac_dpsi = diotadpsi * m / (saw_omega * (G + iota*I)) - alpha_fac / (G+iota*I) * (dGdpsi + diotadpsi*I + iota*dIdpsi);
 
-            double pt_cos = cos(m*theta - n*zeta + saw_omega*time);
-            double pt_sin = sin(m*theta - n*zeta + saw_omega*time);
+            double pt_cos = cos(m*theta - n*zeta + saw_omega*time + saw_phases[i]);
+            double pt_sin = sin(m*theta - n*zeta + saw_omega*time + saw_phases[i]);
 
             double phihat_i = left_phihat + s_slope*(s_diff);
             double dphihatdpsi = s_slope / psi0_d;
@@ -1109,7 +1109,7 @@ extern "C" vector<double> boozer_gpu_tracing(py::array_t<double> quad_pts, py::a
 
 
 extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, py::array_t<double> mus, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles){
 
     //  read data in from python
@@ -1119,6 +1119,7 @@ extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, p
     int* saw_m_arr = create_array(saw_m);
     int* saw_n_arr = create_array(saw_n);
     double* saw_phihats_arr = create_array(saw_phihats);
+    double* saw_phases_arr = create_array(saw_phases);
 
     double* mus_d;
     gpuErrchk( cudaMalloc((void**)&mus_d, mus.size() * sizeof(double)) );
@@ -1135,6 +1136,10 @@ extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, p
     double* saw_phihats_d;
     gpuErrchk( cudaMalloc((void**)&saw_phihats_d, saw_phihats.size() * sizeof(double)) );
     gpuErrchk( cudaMemcpy(saw_phihats_d, saw_phihats_arr, saw_phihats.size() * sizeof(double), cudaMemcpyHostToDevice) );
+
+    double* saw_phases_d;
+    gpuErrchk( cudaMalloc((void**)&saw_phases_d, saw_phases.size() * sizeof(double)) );
+    gpuErrchk( cudaMemcpy(saw_phases_d, saw_phases_arr, saw_phases.size() * sizeof(double), cudaMemcpyHostToDevice) );
     
     for(int i=0; i<nparticles; ++i){
         double s = stz_init_arr[3*i];
@@ -1153,12 +1158,13 @@ extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, p
     gpuErrchk(cudaMemcpyToSymbol(psi0_d, &psi0, sizeof(double)));
 
     std::vector<double> results =  gpu_tracing<RHS::GC_BoozerVacuumSAW>(quad_pts, srange, trange, zrange, stz_init, m, q, vtotal, vtang, tmax, tol, dt_in, nparticles, mus_d,
-                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_nharmonics);
+                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_phases_d, saw_nharmonics);
 
     gpuErrchk( cudaFree(mus_d) );
     gpuErrchk( cudaFree(saw_m_d) );
     gpuErrchk( cudaFree(saw_n_d) );
     gpuErrchk( cudaFree(saw_phihats_d) );
+    gpuErrchk( cudaFree(saw_phases_d) );
 
     for(int i=0; i<nparticles; ++i){
         double x1 = results[6*i+1];
@@ -1172,7 +1178,7 @@ extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, p
 }
 
 extern "C" vector<double> boozer_saw_nok_gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, py::array_t<double> mus, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles){
 
     //  read data in from python
@@ -1182,6 +1188,7 @@ extern "C" vector<double> boozer_saw_nok_gpu_tracing(py::array_t<double> quad_pt
     int* saw_m_arr = create_array(saw_m);
     int* saw_n_arr = create_array(saw_n);
     double* saw_phihats_arr = create_array(saw_phihats);
+    double* saw_phases_arr = create_array(saw_phases);
 
     double* mus_d;
     gpuErrchk( cudaMalloc((void**)&mus_d, mus.size() * sizeof(double)) );
@@ -1198,6 +1205,10 @@ extern "C" vector<double> boozer_saw_nok_gpu_tracing(py::array_t<double> quad_pt
     double* saw_phihats_d;
     cudaMalloc((void**)&saw_phihats_d, saw_phihats.size() * sizeof(double));
     cudaMemcpy(saw_phihats_d, saw_phihats_arr, saw_phihats.size() * sizeof(double), cudaMemcpyHostToDevice);
+
+    double* saw_phases_d;
+    gpuErrchk( cudaMalloc((void**)&saw_phases_d, saw_phases.size() * sizeof(double)) );
+    gpuErrchk( cudaMemcpy(saw_phases_d, saw_phases_arr, saw_phases.size() * sizeof(double), cudaMemcpyHostToDevice) );
     
     for(int i=0; i<nparticles; ++i){
         double s = stz_init_arr[3*i];
@@ -1216,12 +1227,13 @@ extern "C" vector<double> boozer_saw_nok_gpu_tracing(py::array_t<double> quad_pt
     gpuErrchk(cudaMemcpyToSymbol(psi0_d, &psi0, sizeof(double)));
 
     std::vector<double> results =  gpu_tracing<RHS::GC_BoozerNoKSAW>(quad_pts, srange, trange, zrange, stz_init, m, q, vtotal, vtang, tmax, tol, dt_in, nparticles, mus_d,
-                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_nharmonics);
+                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_phases_d, saw_nharmonics);
 
     gpuErrchk( cudaFree(mus_d) );
     gpuErrchk( cudaFree(saw_m_d) );
     gpuErrchk( cudaFree(saw_n_d) );
     gpuErrchk( cudaFree(saw_phihats_d) );
+    gpuErrchk( cudaFree(saw_phases_d) );
 
     for(int i=0; i<nparticles; ++i){
         double x1 = results[6*i+1];
@@ -1623,13 +1635,14 @@ extern "C" py::array_t<double> test_derivatives_boozer(py::array_t<double> quad_
 }
 
 extern "C" py::array_t<double> test_derivatives_saw(py::array_t<double> quad_pts, py::array_t<double> x1_range, py::array_t<double> x2_range, py::array_t<double> x3_range, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> loc, py::array_t<double> vpar, py::array_t<double> time, double v_total, double m, double q,  double psi0, int n_points){
 
     double* saw_srange_arr = create_array(saw_srange);
     int* saw_m_arr = create_array(saw_m);
     int* saw_n_arr = create_array(saw_n);
     double* saw_phihats_arr = create_array(saw_phihats);
+    double* saw_phases_arr = create_array(saw_phases);
     
     int* saw_m_d;
     cudaMalloc((void**)&saw_m_d, saw_m.size() * sizeof(int));
@@ -1642,6 +1655,10 @@ extern "C" py::array_t<double> test_derivatives_saw(py::array_t<double> quad_pts
     double* saw_phihats_d;
     cudaMalloc((void**)&saw_phihats_d, saw_phihats.size() * sizeof(double));
     cudaMemcpy(saw_phihats_d, saw_phihats_arr, saw_phihats.size() * sizeof(double), cudaMemcpyHostToDevice);
+
+    double* saw_phases_d;
+    gpuErrchk( cudaMalloc((void**)&saw_phases_d, saw_phases.size() * sizeof(double)) );
+    gpuErrchk( cudaMemcpy(saw_phases_d, saw_phases_arr, saw_phases.size() * sizeof(double), cudaMemcpyHostToDevice) );
 
     // allocate and copy to device memory
     double saw_srange_ext[4];
@@ -1655,22 +1672,24 @@ extern "C" py::array_t<double> test_derivatives_saw(py::array_t<double> quad_pts
     gpuErrchk(cudaMemcpyToSymbol(saw_srange_d, saw_srange_ext, 4*sizeof(double)) );
     
     py::array_t<double> out = test_gpu_derivatives<RHS::GC_BoozerVacuumSAW>(quad_pts, x1_range, x2_range, x3_range, loc, vpar, time, v_total, m, q, n_points,
-                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_nharmonics);
+                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_phases_d, saw_nharmonics);
 
     gpuErrchk( cudaFree(saw_m_d) );
     gpuErrchk( cudaFree(saw_n_d) );
     gpuErrchk( cudaFree(saw_phihats_d) );
+    gpuErrchk( cudaFree(saw_phases_d) );
     return out;
 }
 
 extern "C" py::array_t<double> test_derivatives_saw_nok(py::array_t<double> quad_pts, py::array_t<double> x1_range, py::array_t<double> x2_range, py::array_t<double> x3_range, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> loc, py::array_t<double> vpar, py::array_t<double> time, double v_total, double m, double q,  double psi0, int n_points){
 
     double* saw_srange_arr = create_array(saw_srange);
     int* saw_m_arr = create_array(saw_m);
     int* saw_n_arr = create_array(saw_n);
     double* saw_phihats_arr = create_array(saw_phihats);
+    double* saw_phases_arr = create_array(saw_phases);
 
     int* saw_m_d;
     cudaMalloc((void**)&saw_m_d, saw_m.size() * sizeof(int));
@@ -1684,6 +1703,10 @@ extern "C" py::array_t<double> test_derivatives_saw_nok(py::array_t<double> quad
     cudaMalloc((void**)&saw_phihats_d, saw_phihats.size() * sizeof(double));
     cudaMemcpy(saw_phihats_d, saw_phihats_arr, saw_phihats.size() * sizeof(double), cudaMemcpyHostToDevice);
 
+    double* saw_phases_d;
+    gpuErrchk( cudaMalloc((void**)&saw_phases_d, saw_phases.size() * sizeof(double)) );
+    gpuErrchk( cudaMemcpy(saw_phases_d, saw_phases_arr, saw_phases.size() * sizeof(double), cudaMemcpyHostToDevice) );
+
     // allocate and copy to device memory
     double saw_srange_ext[4];
     for(int i=0; i<3; ++i){
@@ -1695,10 +1718,11 @@ extern "C" py::array_t<double> test_derivatives_saw_nok(py::array_t<double> quad
     gpuErrchk(cudaMemcpyToSymbol(saw_srange_d, saw_srange_ext, 4*sizeof(double)) );
         
     py::array_t<double> out = test_gpu_derivatives<RHS::GC_BoozerNoKSAW>(quad_pts, x1_range, x2_range, x3_range, loc, vpar, time, v_total, m, q, n_points,
-                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_nharmonics);
+                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_phases_d, saw_nharmonics);
     gpuErrchk( cudaFree(saw_m_d) );
     gpuErrchk( cudaFree(saw_n_d) );
     gpuErrchk( cudaFree(saw_phihats_d) );
+    gpuErrchk( cudaFree(saw_phases_d) );
 
     return out;
 }
@@ -1918,7 +1942,7 @@ extern "C" vector<double> test_timestep_boozer(py::array_t<double> quad_pts, py:
 }
 
 extern "C" vector<double> test_timestep_saw(py::array_t<double> quad_pts, py::array_t<double> x1_range, py::array_t<double> x2_range, py::array_t<double> x3_range, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> loc_init, double m, double q, double v_total, py::array_t<double> vtang, py::array_t<double> time,
         double tol, double psi0, int nparticles){
  
@@ -1926,6 +1950,7 @@ extern "C" vector<double> test_timestep_saw(py::array_t<double> quad_pts, py::ar
     int* saw_m_arr = create_array(saw_m);
     int* saw_n_arr = create_array(saw_n);
     double* saw_phihats_arr = create_array(saw_phihats);
+    double* saw_phases_arr = create_array(saw_phases);
 
     int* saw_m_d;
     cudaMalloc((void**)&saw_m_d, saw_m.size() * sizeof(int));
@@ -1938,6 +1963,10 @@ extern "C" vector<double> test_timestep_saw(py::array_t<double> quad_pts, py::ar
     double* saw_phihats_d;
     cudaMalloc((void**)&saw_phihats_d, saw_phihats.size() * sizeof(double));
     cudaMemcpy(saw_phihats_d, saw_phihats_arr, saw_phihats.size() * sizeof(double), cudaMemcpyHostToDevice);
+
+    double* saw_phases_d;
+    gpuErrchk( cudaMalloc((void**)&saw_phases_d, saw_phases.size() * sizeof(double)) );
+    gpuErrchk( cudaMemcpy(saw_phases_d, saw_phases_arr, saw_phases.size() * sizeof(double), cudaMemcpyHostToDevice) );
 
     double* out_d;
     gpuErrchk( cudaMalloc((void**)&out_d, 5 * nparticles * sizeof(double)) );
@@ -1952,7 +1981,7 @@ extern "C" vector<double> test_timestep_saw(py::array_t<double> quad_pts, py::ar
     gpuErrchk(cudaMemcpyToSymbol(psi0_d, &psi0, sizeof(double)));
     gpuErrchk(cudaMemcpyToSymbol(saw_srange_d, saw_srange_ext, 4*sizeof(double)) );
     vector<double> particle_output = test_gpu_timestep<RHS::GC_BoozerVacuumSAW>(quad_pts, x1_range, x2_range, x3_range, loc_init, m, q, v_total, vtang, tol, nparticles,
-                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_nharmonics);
+                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_phases_d, saw_nharmonics);
     for(int i=0; i<nparticles; ++i){
         double x1 = particle_output[5*i + 1];
         double x2 = particle_output[5*i + 2];
@@ -1968,6 +1997,7 @@ extern "C" vector<double> test_timestep_saw(py::array_t<double> quad_pts, py::ar
     gpuErrchk( cudaFree(saw_m_d) );
     gpuErrchk( cudaFree(saw_n_d) );
     gpuErrchk( cudaFree(saw_phihats_d) );
+    gpuErrchk( cudaFree(saw_phases_d) );
     gpuErrchk( cudaFree(out_d) );
  
     return particle_output;
@@ -1975,7 +2005,7 @@ extern "C" vector<double> test_timestep_saw(py::array_t<double> quad_pts, py::ar
 };
 
 extern "C" vector<double> test_timestep_saw_nok(py::array_t<double> quad_pts, py::array_t<double> x1_range, py::array_t<double> x2_range, py::array_t<double> x3_range, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> loc_init, double m, double q, double v_total, py::array_t<double> vtang, py::array_t<double> time,
         double tol, double psi0, int nparticles){
  
@@ -1983,6 +2013,7 @@ extern "C" vector<double> test_timestep_saw_nok(py::array_t<double> quad_pts, py
     int* saw_m_arr = create_array(saw_m);
     int* saw_n_arr = create_array(saw_n);
     double* saw_phihats_arr = create_array(saw_phihats);
+    double* saw_phases_arr = create_array(saw_phases);
 
     int* saw_m_d;
     cudaMalloc((void**)&saw_m_d, saw_m.size() * sizeof(int));
@@ -1995,6 +2026,10 @@ extern "C" vector<double> test_timestep_saw_nok(py::array_t<double> quad_pts, py
     double* saw_phihats_d;
     cudaMalloc((void**)&saw_phihats_d, saw_phihats.size() * sizeof(double));
     cudaMemcpy(saw_phihats_d, saw_phihats_arr, saw_phihats.size() * sizeof(double), cudaMemcpyHostToDevice);
+
+    double* saw_phases_d;
+    gpuErrchk( cudaMalloc((void**)&saw_phases_d, saw_phases.size() * sizeof(double)) );
+    gpuErrchk( cudaMemcpy(saw_phases_d, saw_phases_arr, saw_phases.size() * sizeof(double), cudaMemcpyHostToDevice) );
 
     double* out_d;
     gpuErrchk( cudaMalloc((void**)&out_d, 5 * nparticles * sizeof(double)) );
@@ -2009,7 +2044,7 @@ extern "C" vector<double> test_timestep_saw_nok(py::array_t<double> quad_pts, py
     gpuErrchk(cudaMemcpyToSymbol(psi0_d, &psi0, sizeof(double)));
     gpuErrchk(cudaMemcpyToSymbol(saw_srange_d, saw_srange_ext, 4*sizeof(double)) );
     vector<double> particle_output = test_gpu_timestep<RHS::GC_BoozerNoKSAW>(quad_pts, x1_range, x2_range, x3_range, loc_init, m, q, v_total, vtang, tol, nparticles,
-                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_nharmonics);
+                                                                        saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_phases_d, saw_nharmonics);
     for(int i=0; i<nparticles; ++i){
         double x1 = particle_output[5*i + 1];
         double x2 = particle_output[5*i + 2];
@@ -2025,6 +2060,7 @@ extern "C" vector<double> test_timestep_saw_nok(py::array_t<double> quad_pts, py
     gpuErrchk( cudaFree(saw_m_d) );
     gpuErrchk( cudaFree(saw_n_d) );
     gpuErrchk( cudaFree(saw_phihats_d) );
+    gpuErrchk( cudaFree(saw_phases_d) );
     gpuErrchk( cudaFree(out_d) );
 
     return particle_output;

--- a/src/firm3dpp/cuda_kernel.cu
+++ b/src/firm3dpp/cuda_kernel.cu
@@ -913,6 +913,9 @@ __global__ void particle_trace_kernel(double* out, double* init_pos, double* qua
             state[i*PARTICLES_PER_BLOCK + threadIdx.x] = init_pos[4*idx + i];
         }
         dt[threadIdx.x] = dt_in[threadIdx.x]; // copy input dt
+        if(mus_init != nullptr){
+            mu[threadIdx.x] = mus_init[idx];
+        }
     }
     __syncthreads();
 

--- a/src/firm3dpp/cuda_kernel.cu
+++ b/src/firm3dpp/cuda_kernel.cu
@@ -881,7 +881,7 @@ __device__ void adjust_time(double* t, double* dt, double* state, double* derivs
  * Everything lives in shared memory except the data for the interpolant
  */
 template<RHS id, typename... Args>
-__global__ void particle_trace_kernel(double* out, double* init_pos, double* quadpts_arr, double* dt_in, Args... args){
+__global__ void particle_trace_kernel(double* out, double* init_pos, double* quadpts_arr, double* dt_in, double* mus_init, Args... args){
     int idx = threadIdx.x + blockIdx.x*PARTICLES_PER_BLOCK;
 
     __shared__ double x_temp[5 * PARTICLES_PER_BLOCK];
@@ -958,7 +958,7 @@ __global__ void particle_trace_kernel(double* out, double* init_pos, double* qua
 
 template<RHS id, typename... Args>
 vector<double> gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> x1_range, py::array_t<double> x2_range, py::array_t<double> x3_range, 
-    py::array_t<double> loc_init, double m, double q, double vtotal, py::array_t<double> vtang, double tmax, double tol, py::array_t<double> dt_in, int nparticles, Args... args){
+    py::array_t<double> loc_init, double m, double q, double vtotal, py::array_t<double> vtang, double tmax, double tol, py::array_t<double> dt_in, int nparticles, double* mus_d = nullptr, Args... args){
 
     //  read data in from python
     double* loc_init_arr = create_array(loc_init);
@@ -1042,7 +1042,7 @@ vector<double> gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> x1_
     cudaEventCreate(&start);
     cudaEventCreate(&stop);
     cudaEventRecord(start);
-    particle_trace_kernel<id><<<nblks, nthreads>>>(out_d, init_pos_d, quadpts_d, dt_in_d, args...);
+    particle_trace_kernel<id><<<nblks, nthreads>>>(out_d, init_pos_d, quadpts_d, dt_in_d, mus_d, args...);
 
     double out[6*nparticles];
     gpuErrchk(cudaMemcpy(out, out_d, 6 * nparticles * sizeof(double), cudaMemcpyDeviceToHost) );
@@ -1106,10 +1106,15 @@ extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, p
 
     //  read data in from python
     double* stz_init_arr = create_array(stz_init);
+    double* mus_arr = create_array(mus);
     double* saw_srange_arr = create_array(saw_srange);
     int* saw_m_arr = create_array(saw_m);
     int* saw_n_arr = create_array(saw_n);
     double* saw_phihats_arr = create_array(saw_phihats);
+
+    double* mus_d;
+    gpuErrchk( cudaMalloc((void**)&mus_d, mus.size() * sizeof(double)) );
+    gpuErrchk( cudaMemcpy(mus_d, mus_arr, mus.size() * sizeof(double), cudaMemcpyHostToDevice) );
 
     int* saw_m_d;
     gpuErrchk( cudaMalloc((void**)&saw_m_d, saw_m.size() * sizeof(int)) );
@@ -1139,9 +1144,10 @@ extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, p
     gpuErrchk(cudaMemcpyToSymbol(saw_srange_d, saw_srange_ext, 4*sizeof(double)) );
     gpuErrchk(cudaMemcpyToSymbol(psi0_d, &psi0, sizeof(double)));
 
-    std::vector<double> results =  gpu_tracing<RHS::GC_BoozerVacuumSAW>(quad_pts, srange, trange, zrange, stz_init, m, q, vtotal, vtang, tmax, tol, dt_in, nparticles,
+    std::vector<double> results =  gpu_tracing<RHS::GC_BoozerVacuumSAW>(quad_pts, srange, trange, zrange, stz_init, m, q, vtotal, vtang, tmax, tol, dt_in, nparticles, mus_d,
                                                                         saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_nharmonics);
 
+    gpuErrchk( cudaFree(mus_d) );
     gpuErrchk( cudaFree(saw_m_d) );
     gpuErrchk( cudaFree(saw_n_d) );
     gpuErrchk( cudaFree(saw_phihats_d) );
@@ -1163,10 +1169,15 @@ extern "C" vector<double> boozer_saw_nok_gpu_tracing(py::array_t<double> quad_pt
 
     //  read data in from python
     double* stz_init_arr = create_array(stz_init);
+    double* mus_arr = create_array(mus);
     double* saw_srange_arr = create_array(saw_srange);
     int* saw_m_arr = create_array(saw_m);
     int* saw_n_arr = create_array(saw_n);
     double* saw_phihats_arr = create_array(saw_phihats);
+
+    double* mus_d;
+    gpuErrchk( cudaMalloc((void**)&mus_d, mus.size() * sizeof(double)) );
+    gpuErrchk( cudaMemcpy(mus_d, mus_arr, mus.size() * sizeof(double), cudaMemcpyHostToDevice) );
 
     int* saw_m_d;
     cudaMalloc((void**)&saw_m_d, saw_m.size() * sizeof(int));
@@ -1196,9 +1207,10 @@ extern "C" vector<double> boozer_saw_nok_gpu_tracing(py::array_t<double> quad_pt
     gpuErrchk(cudaMemcpyToSymbol(saw_srange_d, saw_srange_ext, 4*sizeof(double)) );
     gpuErrchk(cudaMemcpyToSymbol(psi0_d, &psi0, sizeof(double)));
 
-    std::vector<double> results =  gpu_tracing<RHS::GC_BoozerNoKSAW>(quad_pts, srange, trange, zrange, stz_init, m, q, vtotal, vtang, tmax, tol, dt_in, nparticles,
+    std::vector<double> results =  gpu_tracing<RHS::GC_BoozerNoKSAW>(quad_pts, srange, trange, zrange, stz_init, m, q, vtotal, vtang, tmax, tol, dt_in, nparticles, mus_d,
                                                                         saw_omega, saw_m_d, saw_n_d, saw_phihats_d, saw_nharmonics);
 
+    gpuErrchk( cudaFree(mus_d) );
     gpuErrchk( cudaFree(saw_m_d) );
     gpuErrchk( cudaFree(saw_n_d) );
     gpuErrchk( cudaFree(saw_phihats_d) );

--- a/src/firm3dpp/cuda_kernel.cu
+++ b/src/firm3dpp/cuda_kernel.cu
@@ -1102,7 +1102,7 @@ extern "C" vector<double> boozer_gpu_tracing(py::array_t<double> quad_pts, py::a
 
 extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, 
         double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
-        py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles){
+        py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, py::array_t<double> mus, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles){
 
     //  read data in from python
     double* stz_init_arr = create_array(stz_init);
@@ -1159,7 +1159,7 @@ extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, p
 
 extern "C" vector<double> boozer_saw_nok_gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, 
         double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
-        py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles){
+        py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, py::array_t<double> mus, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles){
 
     //  read data in from python
     double* stz_init_arr = create_array(stz_init);

--- a/src/firm3dpp/cuda_kernel.cu
+++ b/src/firm3dpp/cuda_kernel.cu
@@ -749,13 +749,13 @@ __device__ void calc_max_timestep_size<CoordSys::Boozer>(double* dtmax, double* 
 }
 
 // set up particles for tracing
-// use the derivatives function to calculate mu, max step size
+// use derivatives to calculate max step size; calculate mu if not supplied
 // store these values for the remainder of tracing
 
 template<RHS id, typename... Args>
 __device__ void setup_particle(double* mu, double* t, double* dt, double* dtmax, double* x_temp, bool* symmetry_exploited, int* index_i, int* index_j, int* index_k,
                             double* quad_pts, double* x1_shape, double* x2_shape, double* x3_shape, double* state, double* derivs,
-                            int nparticles_blk, Args... args){
+                            int nparticles_blk, bool use_input_mu, Args... args){
 
     
     if(threadIdx.x < nparticles_blk){
@@ -763,8 +763,10 @@ __device__ void setup_particle(double* mu, double* t, double* dt, double* dtmax,
         symmetry_exploited[threadIdx.x] = false;
         build_state<id>(x_temp, 0, symmetry_exploited, index_i, index_j, index_k,
                                 x1_shape, x2_shape, x3_shape, state, derivs, t, dt);
-        // dummy call to get norm B
-        mu[threadIdx.x] = -1.0; // initialize mu
+        if(!use_input_mu){
+            // dummy call to get norm B
+            mu[threadIdx.x] = -1.0; // initialize mu
+        }
     }
     __syncthreads();
     calc_derivs<id>(derivs, 0, quad_pts, x_temp, symmetry_exploited, index_i, index_j, index_k,
@@ -772,11 +774,13 @@ __device__ void setup_particle(double* mu, double* t, double* dt, double* dtmax,
     __syncthreads();
 
     if(threadIdx.x < nparticles_blk){
-        double v_par = state[3*PARTICLES_PER_BLOCK + threadIdx.x];
-        double v_perp2 = v_total_d*v_total_d - v_par*v_par;
-        
-        double modB = derivs[4*PARTICLES_PER_BLOCK + threadIdx.x];
-        mu[threadIdx.x] = v_perp2 / (2*modB);
+        if(!use_input_mu){
+            double v_par = state[3*PARTICLES_PER_BLOCK + threadIdx.x];
+            double v_perp2 = v_total_d*v_total_d - v_par*v_par;
+
+            double modB = derivs[4*PARTICLES_PER_BLOCK + threadIdx.x];
+            mu[threadIdx.x] = v_perp2 / (2*modB);
+        }
 
         constexpr CoordSys coord = map_rhs_to_coord<id>();
         calc_max_timestep_size<coord>(dtmax, x_temp, derivs);
@@ -921,7 +925,7 @@ __global__ void particle_trace_kernel(double* out, double* init_pos, double* qua
 
     // calculate the particle's magnetic moment mu, dt, dtmax
     setup_particle<id>(mu, t, dt, dtmax, x_temp, symmetry_exploited, index_i, index_j, index_k,
-                        quadpts_arr, x1_shape, x2_shape, x3_shape, state, derivs, nparticles_blk, args...);
+                        quadpts_arr, x1_shape, x2_shape, x3_shape, state, derivs, nparticles_blk, mus_init != nullptr, args...);
     __syncthreads();
 
     // if there exists a particle which is real and hasn't not reached tmax or left, keep tracing
@@ -1483,7 +1487,7 @@ __global__ void test_gpu_derivs_kernel(double* quad_pts, double* loc, double* vp
     __syncthreads();
 
     setup_particle<id>(mu, t, dt, dtmax, x_temp, symmetry_exploited, index_i, index_j, index_k,
-                        quad_pts, r_shape, phi_shape, z_shape, state, derivs, nparticles_blk, args...);
+                        quad_pts, r_shape, phi_shape, z_shape, state, derivs, nparticles_blk, false, args...);
 
     __syncthreads();
 
@@ -1735,7 +1739,7 @@ __global__ void test_gpu_timestep_kernel(double* out, double* init_pos, double* 
 
     // calculate the particle's magnetic moment mu, dt, dtmax
     setup_particle<id>(mu, t, dt, dtmax, x_temp, symmetry_exploited, index_i, index_j, index_k,
-                        quadpts_arr, r_shape, phi_shape, z_shape, state, derivs, nparticles_blk, args...);
+                        quadpts_arr, r_shape, phi_shape, z_shape, state, derivs, nparticles_blk, false, args...);
     __syncthreads();
 
     // if there exists a particle at t=0, which is a real particle, then keep tracing

--- a/src/firm3dpp/python_tracing.cpp
+++ b/src/firm3dpp/python_tracing.cpp
@@ -20,21 +20,21 @@ extern "C" vector<double> boozer_gpu_tracing(py::array_t<double> quad_pts, py::a
     double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles, bool vacuum=false);
 
 extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, py::array_t<double> mus, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles);
 
 extern "C" vector<double> boozer_saw_nok_gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, py::array_t<double> mus, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles);
 
 extern "C" py::array_t<double> test_gpu_interpolation(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, py::array_t<double> loc, std::string coordinates, int n_points);
 extern "C" py::array_t<double> test_derivatives_cartesian(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, py::array_t<double> loc, py::array_t<double> vpar, double v_total, double m, double q,  int n_points);
 extern "C" py::array_t<double> test_derivatives_boozer(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, py::array_t<double> loc, py::array_t<double> vpar, double v_total, double m, double q,  double psi0, int n_points, bool vacuum = false);
 extern "C" py::array_t<double> test_derivatives_saw(py::array_t<double> quad_pts, py::array_t<double> x1_range, py::array_t<double> x2_range, py::array_t<double> x3_range, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> loc, py::array_t<double> vpar, py::array_t<double> time, double v_total, double m, double q,  double psi0, int n_points);
 extern "C" py::array_t<double> test_derivatives_saw_nok(py::array_t<double> quad_pts, py::array_t<double> x1_range, py::array_t<double> x2_range, py::array_t<double> x3_range, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> loc, py::array_t<double> vpar, py::array_t<double> time, double v_total, double m, double q,  double psi0, int n_points);
 
 extern "C" vector<double> test_timestep_cartesian(py::array_t<double> quad_pts, py::array_t<double> rrange,
@@ -46,13 +46,13 @@ extern "C" vector<double> test_timestep_boozer(py::array_t<double> quad_pts, py:
         double tol, double psi0, int nparticles, bool vacuum);
         
 extern "C" vector<double> test_timestep_saw(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, py::array_t<double> time,
         double tol, double psi0, int nparticles);
 
 
 extern "C" vector<double> test_timestep_saw_nok(py::array_t<double> quad_pts, py::array_t<double> x1_range, py::array_t<double> x2_range, py::array_t<double> x3_range, 
-        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
+        double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, py::array_t<double> saw_phases, int saw_nharmonics,
         py::array_t<double> loc_init, double m, double q, double v_total, py::array_t<double> vtang, py::array_t<double> time,
         double tol, double psi0, int nparticles);
 #endif
@@ -175,6 +175,7 @@ void init_tracing(py::module_ &m){
         py::arg("saw_m"),
         py::arg("saw_n"),
         py::arg("saw_phihats"),
+        py::arg("saw_phases"),
         py::arg("saw_nharmonics"),
         py::arg("stz_init"),
         py::arg("m"),
@@ -199,6 +200,7 @@ void init_tracing(py::module_ &m){
         py::arg("saw_m"),
         py::arg("saw_n"),
         py::arg("saw_phihats"),
+        py::arg("saw_phases"),
         py::arg("saw_nharmonics"),
         py::arg("stz_init"),
         py::arg("m"),
@@ -262,6 +264,7 @@ void init_tracing(py::module_ &m){
         py::arg("saw_m"),
         py::arg("saw_n"),
         py::arg("saw_phihats"),
+        py::arg("saw_phases"),
         py::arg("saw_nharmonics"),
         py::arg("loc"),
         py::arg("vpar"),
@@ -283,6 +286,7 @@ void init_tracing(py::module_ &m){
         py::arg("saw_m"),
         py::arg("saw_n"),
         py::arg("saw_phihats"),
+        py::arg("saw_phases"),
         py::arg("saw_nharmonics"),
         py::arg("loc"),
         py::arg("vpar"),
@@ -356,6 +360,7 @@ void init_tracing(py::module_ &m){
         py::arg("saw_m"),
         py::arg("saw_n"),
         py::arg("saw_phihats"),
+        py::arg("saw_phases"),
         py::arg("saw_nharmonics"),
         py::arg("stz_init"),
         py::arg("m"),
@@ -378,6 +383,7 @@ void init_tracing(py::module_ &m){
         py::arg("saw_m"),
         py::arg("saw_n"),
         py::arg("saw_phihats"),
+        py::arg("saw_phases"),
         py::arg("saw_nharmonics"),
         py::arg("stz_init"),
         py::arg("m"),

--- a/src/firm3dpp/python_tracing.cpp
+++ b/src/firm3dpp/python_tracing.cpp
@@ -21,11 +21,11 @@ extern "C" vector<double> boozer_gpu_tracing(py::array_t<double> quad_pts, py::a
 
 extern "C" vector<double> boozer_saw_gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, 
         double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
-        py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles);
+        py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, py::array_t<double> mus, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles);
 
 extern "C" vector<double> boozer_saw_nok_gpu_tracing(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, 
         double saw_omega, py::array_t<double> saw_srange, py::array_t<int> saw_m, py::array_t<int> saw_n, py::array_t<double> saw_phihats, int saw_nharmonics,
-        py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles);
+        py::array_t<double> stz_init, double m, double q, double vtotal, py::array_t<double> vtang, py::array_t<double> mus, double tmax, double tol, py::array_t<double> dt_in, double psi0, int nparticles);
 
 extern "C" py::array_t<double> test_gpu_interpolation(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, py::array_t<double> loc, std::string coordinates, int n_points);
 extern "C" py::array_t<double> test_derivatives_cartesian(py::array_t<double> quad_pts, py::array_t<double> srange, py::array_t<double> trange, py::array_t<double> zrange, py::array_t<double> loc, py::array_t<double> vpar, double v_total, double m, double q,  int n_points);
@@ -181,6 +181,7 @@ void init_tracing(py::module_ &m){
         py::arg("q"),
         py::arg("vtotal"),
         py::arg("vtang"),
+        py::arg("mus"),
         py::arg("tmax"),
         py::arg("tol"),
         py::arg("dt_in"),
@@ -204,6 +205,7 @@ void init_tracing(py::module_ &m){
         py::arg("q"),
         py::arg("vtotal"),
         py::arg("vtang"),
+        py::arg("mus"),
         py::arg("tmax"),
         py::arg("tol"),
         py::arg("dt_in"),

--- a/tests/field/test_gpu.py
+++ b/tests/field/test_gpu.py
@@ -337,6 +337,9 @@ def test_derivatives(
 
             saw_m = [field.get_wave(i).Phim for i in range(saw_nharmonics)]
             saw_n = [field.get_wave(i).Phin for i in range(saw_nharmonics)]
+            saw_phases = np.ascontiguousarray(
+                [field.get_wave(i).phase for i in range(saw_nharmonics)], dtype=np.float64
+            )
             saw_phihats = np.ascontiguousarray(
                 np.column_stack(
                     [
@@ -360,6 +363,7 @@ def test_derivatives(
                     saw_m,
                     saw_n,
                     saw_phihats,
+                    saw_phases,
                     saw_nharmonics,
                     stz,
                     vpar,
@@ -381,6 +385,7 @@ def test_derivatives(
                     saw_m,
                     saw_n,
                     saw_phihats,
+                    saw_phases,
                     saw_nharmonics,
                     stz,
                     vpar,
@@ -546,6 +551,9 @@ def test_timestep(
 
             saw_m = [field.get_wave(i).Phim for i in range(saw_nharmonics)]
             saw_n = [field.get_wave(i).Phin for i in range(saw_nharmonics)]
+            saw_phases = np.ascontiguousarray(
+                [field.get_wave(i).phase for i in range(saw_nharmonics)], dtype=np.float64
+            )
             saw_phihats = np.ascontiguousarray(
                 np.column_stack(
                     [
@@ -568,6 +576,7 @@ def test_timestep(
                     saw_m=saw_m,
                     saw_n=saw_n,
                     saw_phihats=saw_phihats,
+                    saw_phases=saw_phases,
                     saw_nharmonics=saw_nharmonics,
                     stz_init=stz,
                     m=MASS,
@@ -590,6 +599,7 @@ def test_timestep(
                     saw_m=saw_m,
                     saw_n=saw_n,
                     saw_phihats=saw_phihats,
+                    saw_phases=saw_phases,
                     saw_nharmonics=saw_nharmonics,
                     stz_init=stz,
                     m=MASS,
@@ -776,6 +786,9 @@ class TestGPUTracing(unittest.TestCase):
             minor_radius_meters=1.7,
         )
 
+        for i in range(len(saw)):
+            saw.get_wave(i).phase = i * np.pi / 4
+
         n_test_pts = 10000
         stz = sample_test_points(n_test_pts)
         tol = 1e-8
@@ -834,6 +847,9 @@ class TestGPUTracing(unittest.TestCase):
             max_dB_normal_by_B0=5e-3,
             minor_radius_meters=1.7,
         )
+
+        for i in range(len(saw)):
+            saw.get_wave(i).phase = i * np.pi / 4
 
         n_test_pts = 10000
         stz = sample_test_points(n_test_pts)


### PR DESCRIPTION
Improvements for tracing with SAW:

1) Adding phase of the harmonic, so that the mode can consist of cos and sin terms. This matches current CPU behavior.
2) Computing and passing mu instead of vtotal: this allows evolving distribution of ICs from slow-down distribution and matches current CPU behavior.

## Summary by Sourcery

Update SAW GPU tracing to support harmonic phases and initialize particles from kinetic energy and magnetic moment.

New Features:
- Support per-harmonic phases in SAW field tracing and derivative/timestep interfaces.
- Add a perturbed Boozer tracing API that accepts scalar or per-particle initial kinetic energies and evolves supplied magnetic moments.

Bug Fixes:
- Align SAW GPU tracing with CPU behavior by using phase-aware harmonics and energy-derived magnetic moments.

Enhancements:
- Preserve the existing monoenergetic tracing interface while using a reference speed for solver scaling and validating particle inputs.

Tests:
- Extend GPU derivative and timestep coverage to pass harmonic phases and exercise nonzero phase values.